### PR TITLE
feat: (openai) forward FunctionCallingConfig.Mode as tool_choice

### DIFF
--- a/genai/openai/openai.go
+++ b/genai/openai/openai.go
@@ -311,6 +311,45 @@ func (m *Model) applyGenerationConfig(params *openai.ChatCompletionNewParams, cf
 			params.Tools = tools
 		}
 	}
+
+	// ToolConfig → tool_choice
+	//
+	// Maps genai.FunctionCallingConfig.Mode to OpenAI's tool_choice:
+	//   ModeAuto → "auto"   (default behaviour; model may or may not call a tool)
+	//   ModeAny  → "required" (model MUST call a tool; use for agentic loops
+	//                         that can't handle a plain-text reply)
+	//   ModeNone → "none"   (tools disabled for this call even if provided)
+	//
+	// When AllowedFunctionNames is set with ModeAny, OpenAI's equivalent is a
+	// named function choice — we pick the first name since OpenAI's
+	// tool_choice accepts only one specific function, not a list. Callers who
+	// need a multi-function allowlist should rely on ModeAny plus prompt-level
+	// instructions to pick within the allowed set.
+	if cfg.ToolConfig != nil && cfg.ToolConfig.FunctionCallingConfig != nil {
+		fcc := cfg.ToolConfig.FunctionCallingConfig
+		switch fcc.Mode {
+		case genai.FunctionCallingConfigModeAuto:
+			params.ToolChoice = openai.ChatCompletionToolChoiceOptionUnionParam{
+				OfAuto: openai.String("auto"),
+			}
+		case genai.FunctionCallingConfigModeNone:
+			params.ToolChoice = openai.ChatCompletionToolChoiceOptionUnionParam{
+				OfAuto: openai.String("none"),
+			}
+		case genai.FunctionCallingConfigModeAny:
+			if len(fcc.AllowedFunctionNames) == 1 {
+				params.ToolChoice = openai.ToolChoiceOptionFunctionToolChoice(
+					openai.ChatCompletionNamedToolChoiceFunctionParam{
+						Name: fcc.AllowedFunctionNames[0],
+					},
+				)
+			} else {
+				params.ToolChoice = openai.ChatCompletionToolChoiceOptionUnionParam{
+					OfAuto: openai.String("required"),
+				}
+			}
+		}
+	}
 }
 
 // convertContentToMessages converts a genai.Content into OpenAI message format.

--- a/genai/openai/openai_test.go
+++ b/genai/openai/openai_test.go
@@ -1,0 +1,97 @@
+// Copyright 2025 achetronic
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package openai
+
+import (
+	"testing"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/packages/param"
+	"google.golang.org/genai"
+)
+
+// applyGenerationConfig must translate genai.ToolConfig.FunctionCallingConfig
+// into OpenAI's tool_choice field. Without this, models that drift into
+// plain-text replies under tool_choice="auto" (the OpenAI default) cannot be
+// forced into tool-calling mode via the ADK config — the setting is silently
+// dropped before it reaches the wire.
+func TestApplyGenerationConfig_ToolChoice(t *testing.T) {
+	cases := []struct {
+		name         string
+		cfg          *genai.GenerateContentConfig
+		wantAuto     string // expected OfAuto value; "" means should be unset
+		wantFunction string // expected OfFunctionToolChoice.Function.Name; "" means should be unset
+	}{
+		{
+			name:     "ModeAuto translates to auto",
+			cfg:      &genai.GenerateContentConfig{ToolConfig: &genai.ToolConfig{FunctionCallingConfig: &genai.FunctionCallingConfig{Mode: genai.FunctionCallingConfigModeAuto}}},
+			wantAuto: "auto",
+		},
+		{
+			name:     "ModeNone translates to none",
+			cfg:      &genai.GenerateContentConfig{ToolConfig: &genai.ToolConfig{FunctionCallingConfig: &genai.FunctionCallingConfig{Mode: genai.FunctionCallingConfigModeNone}}},
+			wantAuto: "none",
+		},
+		{
+			name:     "ModeAny without allowed names translates to required",
+			cfg:      &genai.GenerateContentConfig{ToolConfig: &genai.ToolConfig{FunctionCallingConfig: &genai.FunctionCallingConfig{Mode: genai.FunctionCallingConfigModeAny}}},
+			wantAuto: "required",
+		},
+		{
+			name: "ModeAny with a single allowed name pins to that function",
+			cfg: &genai.GenerateContentConfig{ToolConfig: &genai.ToolConfig{FunctionCallingConfig: &genai.FunctionCallingConfig{
+				Mode:                 genai.FunctionCallingConfigModeAny,
+				AllowedFunctionNames: []string{"my_tool"},
+			}}},
+			wantFunction: "my_tool",
+		},
+		{
+			name: "ModeAny with multiple allowed names falls back to required",
+			cfg: &genai.GenerateContentConfig{ToolConfig: &genai.ToolConfig{FunctionCallingConfig: &genai.FunctionCallingConfig{
+				Mode:                 genai.FunctionCallingConfigModeAny,
+				AllowedFunctionNames: []string{"a", "b"},
+			}}},
+			wantAuto: "required",
+		},
+		{
+			name:     "No ToolConfig leaves tool_choice unset",
+			cfg:      &genai.GenerateContentConfig{},
+			wantAuto: "",
+		},
+		{
+			name:     "Nil FunctionCallingConfig leaves tool_choice unset",
+			cfg:      &genai.GenerateContentConfig{ToolConfig: &genai.ToolConfig{}},
+			wantAuto: "",
+		},
+	}
+
+	m := &Model{modelName: "test-model"}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var params openai.ChatCompletionNewParams
+			m.applyGenerationConfig(&params, tc.cfg)
+
+			gotAuto := ""
+			if !param.IsOmitted(params.ToolChoice.OfAuto) {
+				gotAuto = params.ToolChoice.OfAuto.Value
+			}
+			if gotAuto != tc.wantAuto {
+				t.Errorf("OfAuto = %q, want %q", gotAuto, tc.wantAuto)
+			}
+
+			gotFunction := ""
+			if params.ToolChoice.OfFunctionToolChoice != nil {
+				gotFunction = params.ToolChoice.OfFunctionToolChoice.Function.Name
+			}
+			if gotFunction != tc.wantFunction {
+				t.Errorf("OfFunctionToolChoice.Function.Name = %q, want %q", gotFunction, tc.wantFunction)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`applyGenerationConfig` copies most `genai.GenerateContentConfig` fields through to `openai.ChatCompletionNewParams` (Temperature, MaxTokens, TopP, StopSequences, ThinkingConfig, ResponseMIMEType, ResponseSchema, Tools) but skips the sibling `ToolConfig` entirely. Callers who set `ToolConfig.FunctionCallingConfig.Mode` to control tool-calling behaviour find their setting silently dropped before it hits the wire.

## Observed symptom

On providers routing to RP-oriented models like Kimi K2 (`moonshotai/kimi-k2-0905` via OpenRouter), without an explicit `tool_choice` the model occasionally drifts into producing text replies that hand-format tool calls as prose — e.g. `maya:0{"stimulus": "..."}` — stranding agentic loops that need a real native tool call. Setting `Mode: ANY` on the genai config looks like it should force the issue but has no effect today.

## Change

Translate `FunctionCallingConfig.Mode` → OpenAI's `tool_choice`:

| genai | OpenAI |
|---|---|
| `ModeAuto` | `"auto"` |
| `ModeNone` | `"none"` |
| `ModeAny` (no allowed names) | `"required"` |
| `ModeAny` + single `AllowedFunctionNames` | named function choice pinned to that name |
| `ModeAny` + multiple `AllowedFunctionNames` | `"required"` (OpenAI's `tool_choice` takes one function, not a list — callers who need a multi-function allowlist rely on `ModeAny` + prompt-level guidance) |

## Tests

The `genai/openai/` package didn't have an `_test.go` file, so this PR adds `openai_test.go` covering the seven relevant combinations: each of the three modes, both `AllowedFunctionNames` branches of `ModeAny`, and the two "leave `tool_choice` unset" paths (nil `ToolConfig`, nil `FunctionCallingConfig`). All pass locally.

## Compatibility

Backwards-compatible: callers who don't set `ToolConfig` keep the current behaviour (tool_choice is left unset, OpenAI's default applies). No existing API surface changes.