### PR TITLE
feat: (anthropic) Forward FunctionCallingConfig.Mode as tool_choice

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -114,8 +114,8 @@ adk-utils-go/
 
 | Package | Description |
 |---------|-------------|
-| `genai/openai` | OpenAI/Ollama-compatible `model.LLM` adapter |
-| `genai/anthropic` | Anthropic Claude `model.LLM` adapter |
+| `genai/openai` | OpenAI/Ollama-compatible `model.LLM` adapter (forwards `ToolConfig.FunctionCallingConfig.Mode` as `tool_choice`) |
+| `genai/anthropic` | Anthropic Claude `model.LLM` adapter (forwards `ToolConfig.FunctionCallingConfig.Mode` as `tool_choice`) |
 | `session/redis` | Redis-backed implementation of `session.Service` |
 | `memory/memorytypes` | Shared types (`EntryWithID`) and interfaces (`MemoryService`, `ExtendedMemoryService`) |
 | `memory/postgres` | PostgreSQL+pgvector implementation of `memory.Service` and `ExtendedMemoryService` |
@@ -369,4 +369,28 @@ AfterModelCallback:
   persist PromptTokenCount for next step's calibration
 ```
 
+---
+
+## LLM Adapters — tool_choice Mapping
+
+Both `genai/openai` and `genai/anthropic` translate `genai.GenerateContentConfig.ToolConfig.FunctionCallingConfig` into the provider-native `tool_choice` field during `applyGenerationConfig` / `buildMessageParams`. ADK propagates `ToolConfig` through `basic_processor.go` (`req.Config = clone(state.GenerateContentConfig)`), so the field arrives untouched at the adapter.
+
+Without this translation, callers setting `Mode: ANY` on an LLM agent see the setting silently dropped — the typical symptom being models like Kimi K2 or certain Claude variants producing plain-text replies that hand-format tool calls as prose, stranding agentic loops that require a native function call.
+
+### Shared mapping (identical semantics across providers)
+
+| genai `FunctionCallingConfig.Mode` | OpenAI `tool_choice` | Anthropic `tool_choice` |
+|---|---|---|
+| `ModeUnspecified` (zero value) | unset | unset |
+| `ModeAuto` | `"auto"` | `{type: "auto"}` |
+| `ModeNone` | `"none"` | `{type: "none"}` |
+| `ModeAny`, no `AllowedFunctionNames` | `"required"` | `{type: "any"}` |
+| `ModeAny`, exactly one name | named function choice | `{type: "tool", name: <n>}` |
+| `ModeAny`, multiple names | fallback to `"required"` | fallback to `{type: "any"}` |
+
+The multi-name fallback is a pragmatic choice: neither provider accepts a list of allowed names in `tool_choice`. Callers who need a multi-function allowlist should combine `ModeAny` with prompt-level instructions.
+
+### Tests
+
+Each adapter has a table-driven test (`openai_test.go` / `anthropic_test.go`) covering the seven relevant combinations (three modes, two branches of `AllowedFunctionNames`, two "leave it unset" paths). The Anthropic test asserts on the discriminated-union variant (`OfAuto` / `OfAny` / `OfTool` / `OfNone`) rather than the nested `Type` field because the SDK uses `shared/constant` single-value string types whose in-memory zero is `""` — the discriminator is injected during marshaling, and the variant pointer is what the marshaler keys off of.
 

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -12,13 +12,13 @@ A Go library providing utilities for Google's Agent Development Kit (ADK). This 
 
 ### Key Dependencies
 
-| Package | Purpose |
-|---------|---------|
-| `google.golang.org/adk` | Google ADK core framework |
-| `google.golang.org/genai` | Google GenAI types |
-| `github.com/redis/go-redis/v9` | Redis client for session storage |
-| `github.com/lib/pq` | PostgreSQL driver for memory storage |
-| `charm.land/catwalk` | Embedded model registry (564 models, 23 providers) |
+| Package                        | Purpose                                            |
+| ------------------------------ | -------------------------------------------------- |
+| `google.golang.org/adk`        | Google ADK core framework                          |
+| `google.golang.org/genai`      | Google GenAI types                                 |
+| `github.com/redis/go-redis/v9` | Redis client for session storage                   |
+| `github.com/lib/pq`            | PostgreSQL driver for memory storage               |
+| `charm.land/catwalk`           | Embedded model registry (564 models, 23 providers) |
 
 ---
 
@@ -112,17 +112,17 @@ adk-utils-go/
 
 ### Package Purposes
 
-| Package | Description |
-|---------|-------------|
-| `genai/openai` | OpenAI/Ollama-compatible `model.LLM` adapter (forwards `ToolConfig.FunctionCallingConfig.Mode` as `tool_choice`) |
-| `genai/anthropic` | Anthropic Claude `model.LLM` adapter (forwards `ToolConfig.FunctionCallingConfig.Mode` as `tool_choice`) |
-| `session/redis` | Redis-backed implementation of `session.Service` |
-| `memory/memorytypes` | Shared types (`EntryWithID`) and interfaces (`MemoryService`, `ExtendedMemoryService`) |
-| `memory/postgres` | PostgreSQL+pgvector implementation of `memory.Service` and `ExtendedMemoryService` |
-| `artifact/filesystem` | Filesystem-backed `artifact.Service` implementation |
-| `tools/memory` | ADK toolset providing `search_memory`, `save_to_memory`, `update_memory`, and `delete_memory` tools |
-| `plugin/contextguard` | ADK plugin for context window management (threshold + sliding window strategies) |
-| `plugin/langfuse` | ADK plugin for Langfuse observability via OTLP/HTTP (LLM request/response enrichment, token usage, cost tracking) |
+| Package               | Description                                                                                                       |
+| --------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `genai/openai`        | OpenAI/Ollama-compatible `model.LLM` adapter (forwards `ToolConfig.FunctionCallingConfig.Mode` as `tool_choice`)  |
+| `genai/anthropic`     | Anthropic Claude `model.LLM` adapter (forwards `ToolConfig.FunctionCallingConfig.Mode` as `tool_choice`)          |
+| `session/redis`       | Redis-backed implementation of `session.Service`                                                                  |
+| `memory/memorytypes`  | Shared types (`EntryWithID`) and interfaces (`MemoryService`, `ExtendedMemoryService`)                            |
+| `memory/postgres`     | PostgreSQL+pgvector implementation of `memory.Service` and `ExtendedMemoryService`                                |
+| `artifact/filesystem` | Filesystem-backed `artifact.Service` implementation                                                               |
+| `tools/memory`        | ADK toolset providing `search_memory`, `save_to_memory`, `update_memory`, and `delete_memory` tools               |
+| `plugin/contextguard` | ADK plugin for context window management (threshold + sliding window strategies)                                  |
+| `plugin/langfuse`     | ADK plugin for Langfuse observability via OTLP/HTTP (LLM request/response enrichment, token usage, cost tracking) |
 
 ---
 
@@ -166,6 +166,7 @@ userstate:{appName}:{userID}             # Per-user state (HASH, shared across a
 ### PostgreSQL Schema
 
 The `memory_entries` table uses:
+
 - Composite unique constraint: `(app_name, user_id, session_id, event_id)`
 - Full-text search via `tsvector` on `content_text`
 - Vector similarity search via `pgvector` extension on `embedding` column (optional)
@@ -244,7 +245,7 @@ This codebase uses Go 1.24's `iter.Seq` and `iter.Seq2` for iteration:
 // State iteration
 func (s *State) All() iter.Seq2[string, any]
 
-// Events iteration  
+// Events iteration
 func (e *Events) All() iter.Seq[*session.Event]
 ```
 
@@ -313,13 +314,13 @@ cfg := guard.PluginConfig()           // runner.PluginConfig with BeforeModelCal
 
 ### State Keys
 
-| Key | Set by | Read by | Purpose |
-|---|---|---|---|
-| `__context_guard_summary_{agent}` | `BeforeModelCallback` | `BeforeModelCallback` | Running conversation summary |
-| `__context_guard_summarized_at_{agent}` | `BeforeModelCallback` | (diagnostic) | Token count at last compaction |
-| `__context_guard_real_tokens_{agent}` | `AfterModelCallback` | `BeforeModelCallback` | Real `PromptTokenCount` from provider |
-| `__context_guard_last_heuristic_{agent}` | `BeforeModelCallback` | `BeforeModelCallback` | Heuristic estimate for calibration |
-| `__context_guard_contents_at_compaction_{agent}` | Sliding window | Sliding window | Watermark for turn counting |
+| Key                                              | Set by                | Read by               | Purpose                               |
+| ------------------------------------------------ | --------------------- | --------------------- | ------------------------------------- |
+| `__context_guard_summary_{agent}`                | `BeforeModelCallback` | `BeforeModelCallback` | Running conversation summary          |
+| `__context_guard_summarized_at_{agent}`          | `BeforeModelCallback` | (diagnostic)          | Token count at last compaction        |
+| `__context_guard_real_tokens_{agent}`            | `AfterModelCallback`  | `BeforeModelCallback` | Real `PromptTokenCount` from provider |
+| `__context_guard_last_heuristic_{agent}`         | `BeforeModelCallback` | `BeforeModelCallback` | Heuristic estimate for calibration    |
+| `__context_guard_contents_at_compaction_{agent}` | Sliding window        | Sliding window        | Watermark for turn counting           |
 
 ### File Naming Convention
 
@@ -348,10 +349,10 @@ Cover 200k and 8k context windows, token ratios 1.5x-4.0x, with/without UsageMet
 
 ### Strategies
 
-| Strategy | Trigger | Compaction mode | Config |
-|---|---|---|---|
-| `threshold` | calibrated tokens > (contextWindow - buffer) | Full summary (entire conversation) | `WithMaxTokens(n)` or auto from registry |
-| `sliding_window` | turns since last compaction > maxTurns | Split: summarize old, keep recent tail | `WithSlidingWindow(n)` |
+| Strategy         | Trigger                                      | Compaction mode                        | Config                                   |
+| ---------------- | -------------------------------------------- | -------------------------------------- | ---------------------------------------- |
+| `threshold`      | calibrated tokens > (contextWindow - buffer) | Full summary (entire conversation)     | `WithMaxTokens(n)` or auto from registry |
+| `sliding_window` | turns since last compaction > maxTurns       | Split: summarize old, keep recent tail | `WithSlidingWindow(n)`                   |
 
 Buffer: fixed 20k for windows >=200k, 20% for smaller ones.
 
@@ -379,18 +380,17 @@ Without this translation, callers setting `Mode: ANY` on an LLM agent see the se
 
 ### Shared mapping (identical semantics across providers)
 
-| genai `FunctionCallingConfig.Mode` | OpenAI `tool_choice` | Anthropic `tool_choice` |
-|---|---|---|
-| `ModeUnspecified` (zero value) | unset | unset |
-| `ModeAuto` | `"auto"` | `{type: "auto"}` |
-| `ModeNone` | `"none"` | `{type: "none"}` |
-| `ModeAny`, no `AllowedFunctionNames` | `"required"` | `{type: "any"}` |
-| `ModeAny`, exactly one name | named function choice | `{type: "tool", name: <n>}` |
-| `ModeAny`, multiple names | fallback to `"required"` | fallback to `{type: "any"}` |
+| genai `FunctionCallingConfig.Mode`   | OpenAI `tool_choice`     | Anthropic `tool_choice`     |
+| ------------------------------------ | ------------------------ | --------------------------- |
+| `ModeUnspecified` (zero value)       | unset                    | unset                       |
+| `ModeAuto`                           | `"auto"`                 | `{type: "auto"}`            |
+| `ModeNone`                           | `"none"`                 | `{type: "none"}`            |
+| `ModeAny`, no `AllowedFunctionNames` | `"required"`             | `{type: "any"}`             |
+| `ModeAny`, exactly one name          | named function choice    | `{type: "tool", name: <n>}` |
+| `ModeAny`, multiple names            | fallback to `"required"` | fallback to `{type: "any"}` |
 
 The multi-name fallback is a pragmatic choice: neither provider accepts a list of allowed names in `tool_choice`. Callers who need a multi-function allowlist should combine `ModeAny` with prompt-level instructions.
 
 ### Tests
 
 Each adapter has a table-driven test (`openai_test.go` / `anthropic_test.go`) covering the seven relevant combinations (three modes, two branches of `AllowedFunctionNames`, two "leave it unset" paths). The Anthropic test asserts on the discriminated-union variant (`OfAuto` / `OfAny` / `OfTool` / `OfNone`) rather than the nested `Type` field because the SDK uses `shared/constant` single-value string types whose in-memory zero is `""` — the discriminator is injected during marshaling, and the variant pointer is what the marshaler keys off of.
-

--- a/.agents/TODOS.md
+++ b/.agents/TODOS.md
@@ -1,3 +1,9 @@
 # TODOs
 
-No pending tasks.
+## Follow-ups from PR #12 (`feat: (openai) forward FunctionCallingConfig.Mode as tool_choice`)
+
+Merged in `b4f327d`. These are deferred items discussed during review:
+
+- [ ] **Test for `ModeUnspecified`** in `genai/openai/openai_test.go` and `genai/anthropic/anthropic_test.go`: verify that the zero value of `FunctionCallingConfigMode` leaves `params.ToolChoice` untouched. Today both adapters do the right thing (the value falls through the switch default and no branch assigns), but no test pins it down. If someone later refactors the switch into a map lookup or adds a catch-all `default` clause, the behaviour could silently change to a specific `tool_choice` value. A regression test per adapter, modelled exactly like the existing cases, closes this coverage hole for both providers in one go.
+
+- [ ] **`slog.Warn` when `ModeAny` has `len(AllowedFunctionNames) > 1`** in `genai/openai/openai.go` and `genai/anthropic/anthropic.go`: neither provider's `tool_choice` accepts a list of allowed names, so both adapters currently fall back to a "force tool use, any tool" value (`"required"` for OpenAI, `{type: "any"}` for Anthropic). That is a silent narrowing of the caller's intent — someone writing `AllowedFunctionNames: ["a", "b"]` expects "the model must pick one of these two", not "the model must pick any available tool". A `slog.Warn` at each fallback point keeps behaviour unchanged but surfaces the mismatch in production logs the first time it happens, instead of requiring someone to diff the wire payload to notice. The comments in both adapters already document the limitation; the log turns documentation into a runtime signal.

--- a/genai/anthropic/anthropic.go
+++ b/genai/anthropic/anthropic.go
@@ -272,6 +272,42 @@ func (m *Model) buildMessageParams(req *model.LLMRequest) (anthropic.MessageNewP
 			}
 			params.Tools = tools
 		}
+
+		// ToolConfig → tool_choice
+		//
+		// Maps genai.FunctionCallingConfig.Mode to Anthropic's tool_choice:
+		//   ModeAuto → {type: "auto"} (default behaviour; model may or may not call a tool)
+		//   ModeAny  → {type: "any"}  (model MUST call a tool; use for agentic loops
+		//                              that can't handle a plain-text reply)
+		//   ModeNone → {type: "none"} (tools disabled for this call even if provided)
+		//
+		// When AllowedFunctionNames holds exactly one name with ModeAny, Anthropic's
+		// equivalent is {type: "tool", name: "..."}. For multiple names we fall back
+		// to {type: "any"} because Anthropic's tool variant accepts a single name,
+		// not a list — same pragmatic choice as the OpenAI adapter. Callers who need
+		// a multi-function allowlist should rely on ModeAny plus prompt-level
+		// instructions to pick within the allowed set.
+		if req.Config.ToolConfig != nil && req.Config.ToolConfig.FunctionCallingConfig != nil {
+			fcc := req.Config.ToolConfig.FunctionCallingConfig
+			switch fcc.Mode {
+			case genai.FunctionCallingConfigModeAuto:
+				params.ToolChoice = anthropic.ToolChoiceUnionParam{
+					OfAuto: &anthropic.ToolChoiceAutoParam{},
+				}
+			case genai.FunctionCallingConfigModeNone:
+				params.ToolChoice = anthropic.ToolChoiceUnionParam{
+					OfNone: &anthropic.ToolChoiceNoneParam{},
+				}
+			case genai.FunctionCallingConfigModeAny:
+				if len(fcc.AllowedFunctionNames) == 1 {
+					params.ToolChoice = anthropic.ToolChoiceParamOfTool(fcc.AllowedFunctionNames[0])
+				} else {
+					params.ToolChoice = anthropic.ToolChoiceUnionParam{
+						OfAny: &anthropic.ToolChoiceAnyParam{},
+					}
+				}
+			}
+		}
 	}
 
 	return params, nil

--- a/genai/anthropic/anthropic_test.go
+++ b/genai/anthropic/anthropic_test.go
@@ -1,0 +1,136 @@
+// Copyright 2025 achetronic
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package anthropic
+
+import (
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"google.golang.org/adk/model"
+	"google.golang.org/genai"
+)
+
+// Anthropic's ToolChoiceUnionParam is a discriminated union with four
+// mutually-exclusive variants (OfAuto / OfAny / OfTool / OfNone). We assert
+// on the variant pointers directly because the nested Type field uses
+// constant.* types whose in-memory zero value is the empty string — their
+// real discriminator is injected during marshaling, not at construction.
+// Checking the pointer-set pattern matches what GetType() does internally
+// and is what the marshaler keys off of.
+type toolChoiceVariant int
+
+const (
+	variantUnset toolChoiceVariant = iota
+	variantAuto
+	variantAny
+	variantTool
+	variantNone
+)
+
+// readVariant inspects the ToolChoiceUnionParam and returns which variant
+// (if any) is populated. Mirrors the discriminator logic the SDK applies
+// during JSON marshaling but avoids going through the marshaler so the test
+// stays fast and free of side effects.
+func readVariant(tc anthropic.ToolChoiceUnionParam) toolChoiceVariant {
+	switch {
+	case tc.OfAuto != nil:
+		return variantAuto
+	case tc.OfAny != nil:
+		return variantAny
+	case tc.OfTool != nil:
+		return variantTool
+	case tc.OfNone != nil:
+		return variantNone
+	default:
+		return variantUnset
+	}
+}
+
+// buildMessageParams must translate genai.ToolConfig.FunctionCallingConfig
+// into Anthropic's tool_choice field. Without this, models that drift into
+// plain-text replies (the same production symptom that motivated the OpenAI
+// adapter fix) cannot be forced into tool-calling mode via the ADK config —
+// the setting is silently dropped before it reaches the wire.
+func TestBuildMessageParams_ToolChoice(t *testing.T) {
+	cases := []struct {
+		name         string
+		cfg          *genai.GenerateContentConfig
+		wantVariant  toolChoiceVariant
+		wantToolName string // only checked when wantVariant == variantTool
+	}{
+		{
+			name:        "ModeAuto translates to auto",
+			cfg:         &genai.GenerateContentConfig{ToolConfig: &genai.ToolConfig{FunctionCallingConfig: &genai.FunctionCallingConfig{Mode: genai.FunctionCallingConfigModeAuto}}},
+			wantVariant: variantAuto,
+		},
+		{
+			name:        "ModeNone translates to none",
+			cfg:         &genai.GenerateContentConfig{ToolConfig: &genai.ToolConfig{FunctionCallingConfig: &genai.FunctionCallingConfig{Mode: genai.FunctionCallingConfigModeNone}}},
+			wantVariant: variantNone,
+		},
+		{
+			name:        "ModeAny without allowed names translates to any",
+			cfg:         &genai.GenerateContentConfig{ToolConfig: &genai.ToolConfig{FunctionCallingConfig: &genai.FunctionCallingConfig{Mode: genai.FunctionCallingConfigModeAny}}},
+			wantVariant: variantAny,
+		},
+		{
+			name: "ModeAny with a single allowed name pins to that tool",
+			cfg: &genai.GenerateContentConfig{ToolConfig: &genai.ToolConfig{FunctionCallingConfig: &genai.FunctionCallingConfig{
+				Mode:                 genai.FunctionCallingConfigModeAny,
+				AllowedFunctionNames: []string{"my_tool"},
+			}}},
+			wantVariant:  variantTool,
+			wantToolName: "my_tool",
+		},
+		{
+			name: "ModeAny with multiple allowed names falls back to any",
+			cfg: &genai.GenerateContentConfig{ToolConfig: &genai.ToolConfig{FunctionCallingConfig: &genai.FunctionCallingConfig{
+				Mode:                 genai.FunctionCallingConfigModeAny,
+				AllowedFunctionNames: []string{"a", "b"},
+			}}},
+			wantVariant: variantAny,
+		},
+		{
+			name:        "No ToolConfig leaves tool_choice unset",
+			cfg:         &genai.GenerateContentConfig{},
+			wantVariant: variantUnset,
+		},
+		{
+			name:        "Nil FunctionCallingConfig leaves tool_choice unset",
+			cfg:         &genai.GenerateContentConfig{ToolConfig: &genai.ToolConfig{}},
+			wantVariant: variantUnset,
+		},
+	}
+
+	m := &Model{modelName: "test-model"}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Exercise the full path from LLMRequest to SDK params rather than
+			// poking at a private helper — keeps the test stable if the mapping
+			// is ever refactored into its own function.
+			params, err := m.buildMessageParams(&model.LLMRequest{Config: tc.cfg})
+			if err != nil {
+				t.Fatalf("buildMessageParams returned error: %v", err)
+			}
+
+			if got := readVariant(params.ToolChoice); got != tc.wantVariant {
+				t.Errorf("ToolChoice variant = %d, want %d", got, tc.wantVariant)
+			}
+
+			if tc.wantVariant == variantTool {
+				if params.ToolChoice.OfTool == nil {
+					t.Fatalf("expected OfTool to be set")
+				}
+				if got := params.ToolChoice.OfTool.Name; got != tc.wantToolName {
+					t.Errorf("ToolChoice.OfTool.Name = %q, want %q", got, tc.wantToolName)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Brings the Anthropic adapter to parity with the OpenAI one (PR #12): without this, callers setting Mode: ANY to force native tool calls had their setting silently dropped, leaving models free to reply with hand-formatted tool calls as prose.
