### PR TITLE
fix(genai): lowercase nested JSON schema types in tool definitions

### DIFF
--- a/genai/anthropic/anthropic.go
+++ b/genai/anthropic/anthropic.go
@@ -432,6 +432,7 @@ func (m *Model) convertTools(genaiTools []*genai.Tool) ([]anthropic.ToolUnionPar
 					}
 				}
 				if m != nil {
+					lowercaseTypes(m)
 					if props, ok := m["properties"]; ok {
 						inputSchema.Properties = props
 					}
@@ -711,4 +712,24 @@ func convertInlineDataToBlock(data *genai.Blob) (*anthropic.ContentBlockParamUni
 // hasContent returns true if the message has at least one content block.
 func hasContent(msg anthropic.MessageParam) bool {
 	return len(msg.Content) > 0
+}
+
+// lowercaseTypes recursively traverses a JSON schema map and lowercases all "type" fields
+// to comply with Anthropic's JSON schema validation.
+func lowercaseTypes(m map[string]any) {
+	for k, v := range m {
+		if k == "type" {
+			if s, ok := v.(string); ok {
+				m[k] = strings.ToLower(s)
+			}
+		} else if vMap, ok := v.(map[string]any); ok {
+			lowercaseTypes(vMap)
+		} else if vList, ok := v.([]any); ok {
+			for _, item := range vList {
+				if itemMap, ok := item.(map[string]any); ok {
+					lowercaseTypes(itemMap)
+				}
+			}
+		}
+	}
 }

--- a/genai/anthropic/anthropic_test.go
+++ b/genai/anthropic/anthropic_test.go
@@ -134,3 +134,4 @@ func TestBuildMessageParams_ToolChoice(t *testing.T) {
 		})
 	}
 }
+

--- a/genai/anthropic/core_test.go
+++ b/genai/anthropic/core_test.go
@@ -1,0 +1,225 @@
+// Copyright 2025 achetronic
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package anthropic
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"google.golang.org/genai"
+)
+
+// convertContentToMessage is the entry point for translating ADK Content into
+// Anthropic message blocks. It must:
+//   - return (nil, nil) when the content has no translatable parts, so that
+//     callers can drop empty turns instead of sending Anthropic a 400 for
+//     "messages must contain at least one block"
+//   - emit one Anthropic block per genai Part that carries data, mapping text,
+//     function calls and function responses each to their own block type
+//   - propagate the Content.Role through convertRoleToAnthropic
+func TestConvertContentToMessage(t *testing.T) {
+	m := &Model{}
+
+	cases := []struct {
+		name      string
+		content   *genai.Content
+		wantNil   bool
+		wantRole  anthropic.MessageParamRole
+		wantTypes []string // ordered block discriminators: "text", "tool_use", "tool_result"
+	}{
+		{
+			name:    "no parts yields nil message",
+			content: &genai.Content{Role: "user", Parts: []*genai.Part{}},
+			wantNil: true,
+		},
+		{
+			name: "single text part",
+			content: &genai.Content{
+				Role:  "user",
+				Parts: []*genai.Part{{Text: "hello world"}},
+			},
+			wantRole:  anthropic.MessageParamRoleUser,
+			wantTypes: []string{"text"},
+		},
+		{
+			name: "function call from model role",
+			content: &genai.Content{
+				Role: "model",
+				Parts: []*genai.Part{
+					{FunctionCall: &genai.FunctionCall{
+						ID:   "call_1",
+						Name: "test_func",
+						Args: map[string]any{"a": 1},
+					}},
+				},
+			},
+			wantRole:  anthropic.MessageParamRoleAssistant,
+			wantTypes: []string{"tool_use"},
+		},
+		{
+			name: "function response from user role",
+			content: &genai.Content{
+				Role: "user",
+				Parts: []*genai.Part{
+					{FunctionResponse: &genai.FunctionResponse{
+						ID:       "call_1",
+						Response: map[string]any{"res": "ok"},
+					}},
+				},
+			},
+			wantRole:  anthropic.MessageParamRoleUser,
+			wantTypes: []string{"tool_result"},
+		},
+		{
+			name: "mixed parts preserve order",
+			content: &genai.Content{
+				Role: "model",
+				Parts: []*genai.Part{
+					{Text: "calling tool"},
+					{FunctionCall: &genai.FunctionCall{ID: "call_2", Name: "test_func"}},
+				},
+			},
+			wantRole:  anthropic.MessageParamRoleAssistant,
+			wantTypes: []string{"text", "tool_use"},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := m.convertContentToMessage(c.content)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if c.wantNil {
+				if got != nil {
+					t.Errorf("expected nil message, got %#v", got)
+				}
+				return
+			}
+
+			if got == nil {
+				t.Fatalf("expected message, got nil")
+			}
+			if got.Role != c.wantRole {
+				t.Errorf("Role = %q, want %q", got.Role, c.wantRole)
+			}
+
+			gotTypes := blockTypes(got.Content)
+			if !equalStringSlices(gotTypes, c.wantTypes) {
+				t.Errorf("block types = %v, want %v", gotTypes, c.wantTypes)
+			}
+		})
+	}
+}
+
+// convertResponse rebuilds a genai.LLMResponse from the SDK's Anthropic
+// Message. We feed it a JSON-decoded Message rather than constructing one in
+// memory because the SDK's content blocks use an opaque discriminated union
+// whose fields are populated during unmarshal — building it manually would
+// require reaching into unexported state and create a brittle dependency on
+// the SDK's internals.
+func TestConvertResponse(t *testing.T) {
+	m := &Model{}
+
+	raw := []byte(`{
+		"id": "msg_1",
+		"role": "assistant",
+		"content": [
+			{"type": "text", "text": "Hello"},
+			{"type": "tool_use", "id": "toolu_1", "name": "my_tool", "input": {"arg": 1}}
+		],
+		"usage": {"input_tokens": 10, "output_tokens": 20},
+		"stop_reason": "end_turn"
+	}`)
+
+	var resp anthropic.Message
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		t.Fatalf("failed to unmarshal Anthropic message fixture: %v", err)
+	}
+
+	got, err := m.convertResponse(&resp)
+	if err != nil {
+		t.Fatalf("convertResponse error: %v", err)
+	}
+
+	if got.FinishReason != genai.FinishReasonStop {
+		t.Errorf("FinishReason = %v, want %v", got.FinishReason, genai.FinishReasonStop)
+	}
+	if !got.TurnComplete {
+		t.Errorf("TurnComplete = false, want true")
+	}
+	if got.UsageMetadata == nil {
+		t.Fatalf("expected usage metadata to be populated")
+	}
+	if got.UsageMetadata.PromptTokenCount != 10 {
+		t.Errorf("PromptTokenCount = %d, want 10", got.UsageMetadata.PromptTokenCount)
+	}
+	if got.UsageMetadata.CandidatesTokenCount != 20 {
+		t.Errorf("CandidatesTokenCount = %d, want 20", got.UsageMetadata.CandidatesTokenCount)
+	}
+	if got.UsageMetadata.TotalTokenCount != 30 {
+		t.Errorf("TotalTokenCount = %d, want 30", got.UsageMetadata.TotalTokenCount)
+	}
+
+	if got.Content == nil {
+		t.Fatalf("expected Content to be populated")
+	}
+	if got.Content.Role != genai.RoleModel {
+		t.Errorf("Content.Role = %q, want %q", got.Content.Role, genai.RoleModel)
+	}
+	if len(got.Content.Parts) != 2 {
+		t.Fatalf("expected 2 parts, got %d", len(got.Content.Parts))
+	}
+	if got.Content.Parts[0].Text != "Hello" {
+		t.Errorf("Parts[0].Text = %q, want %q", got.Content.Parts[0].Text, "Hello")
+	}
+	if got.Content.Parts[1].FunctionCall == nil {
+		t.Fatalf("Parts[1].FunctionCall = nil, want populated")
+	}
+	if got.Content.Parts[1].FunctionCall.Name != "my_tool" {
+		t.Errorf("Parts[1].FunctionCall.Name = %q, want %q", got.Content.Parts[1].FunctionCall.Name, "my_tool")
+	}
+}
+
+// blockTypes returns a discriminator string per block in the order they appear,
+// so tests can assert on shape without reaching into the SDK's union internals.
+func blockTypes(blocks []anthropic.ContentBlockParamUnion) []string {
+	out := make([]string, 0, len(blocks))
+	for _, b := range blocks {
+		switch {
+		case b.OfText != nil:
+			out = append(out, "text")
+		case b.OfToolUse != nil:
+			out = append(out, "tool_use")
+		case b.OfToolResult != nil:
+			out = append(out, "tool_result")
+		case b.OfImage != nil:
+			out = append(out, "image")
+		case b.OfDocument != nil:
+			out = append(out, "document")
+		default:
+			out = append(out, "unknown")
+		}
+	}
+	return out
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/genai/anthropic/inline_data_test.go
+++ b/genai/anthropic/inline_data_test.go
@@ -1,0 +1,119 @@
+// Copyright 2025 achetronic
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package anthropic
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"google.golang.org/genai"
+)
+
+// convertInlineDataToBlock routes a genai.Blob to the right Anthropic content
+// block based on MIME type:
+//   - all image types Anthropic supports become OfImage with a base64 source
+//   - application/pdf becomes OfDocument with a base64 PDF source
+//   - text/* becomes OfDocument with a plain-text source (Anthropic accepts
+//     raw text rather than base64 here, so we pass data.Data through verbatim)
+//   - anything else is rejected with an error
+//
+// We assert on which OfXxx variant ends up populated, plus the relevant
+// payload field, instead of stringifying the entire union — that keeps the
+// tests stable across SDK refactors that may shuffle field names while
+// preserving the discriminator.
+func TestConvertInlineDataToBlock(t *testing.T) {
+	cases := []struct {
+		name     string
+		mime     string
+		data     []byte
+		wantKind string
+		wantErr  bool
+	}{
+		{name: "image/png", mime: "image/png", data: []byte("png"), wantKind: "image"},
+		{name: "image/jpeg", mime: "image/jpeg", data: []byte("jpg"), wantKind: "image"},
+		{name: "image/jpg alias", mime: "image/jpg", data: []byte("jpg"), wantKind: "image"},
+		{name: "image/gif", mime: "image/gif", data: []byte("gif"), wantKind: "image"},
+		{name: "image/webp", mime: "image/webp", data: []byte("wbp"), wantKind: "image"},
+		{name: "application/pdf", mime: "application/pdf", data: []byte("%PDF"), wantKind: "pdf"},
+		{name: "text/plain", mime: "text/plain", data: []byte("hello"), wantKind: "text"},
+		{name: "text/html", mime: "text/html", data: []byte("<html/>"), wantKind: "text"},
+		{name: "video/mp4 unsupported", mime: "video/mp4", data: []byte("x"), wantErr: true},
+		{name: "audio/wav unsupported", mime: "audio/wav", data: []byte("x"), wantErr: true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := convertInlineDataToBlock(&genai.Blob{MIMEType: c.mime, Data: c.data})
+			if c.wantErr {
+				if err == nil {
+					t.Errorf("expected error for MIME %q, got %#v", c.mime, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got == nil {
+				t.Fatalf("nil block returned")
+			}
+
+			switch c.wantKind {
+			case "image":
+				img := got.OfImage
+				if img == nil {
+					t.Fatalf("expected OfImage variant, got %#v", got)
+				}
+				src := img.Source.OfBase64
+				if src == nil {
+					t.Fatalf("expected base64 image source")
+				}
+				if string(src.MediaType) != c.mime {
+					t.Errorf("MediaType = %q, want %q", src.MediaType, c.mime)
+				}
+				if src.Data != base64.StdEncoding.EncodeToString(c.data) {
+					t.Errorf("base64 payload mismatch")
+				}
+			case "pdf":
+				doc := got.OfDocument
+				if doc == nil {
+					t.Fatalf("expected OfDocument variant")
+				}
+				src := doc.Source.OfBase64
+				if src == nil {
+					t.Fatalf("expected base64 PDF source")
+				}
+				if src.Data != base64.StdEncoding.EncodeToString(c.data) {
+					t.Errorf("base64 payload mismatch")
+				}
+			case "text":
+				doc := got.OfDocument
+				if doc == nil {
+					t.Fatalf("expected OfDocument variant")
+				}
+				txt := doc.Source.OfText
+				if txt == nil {
+					t.Fatalf("expected plain-text source")
+				}
+				// Anthropic's plain-text source carries raw bytes verbatim,
+				// not base64 — that is the whole point of using OfText
+				// instead of OfBase64.
+				if txt.Data != string(c.data) {
+					t.Errorf("plain text data = %q, want %q", txt.Data, string(c.data))
+				}
+			}
+		})
+	}
+
+	t.Run("nil blob returns an error", func(t *testing.T) {
+		_, err := convertInlineDataToBlock(nil)
+		if err == nil {
+			t.Errorf("expected error for nil blob")
+		}
+	})
+}

--- a/genai/anthropic/repair_test.go
+++ b/genai/anthropic/repair_test.go
@@ -1,0 +1,146 @@
+// Copyright 2025 achetronic
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package anthropic
+
+import (
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+)
+
+// repairMessageHistory enforces Anthropic's invariant that every tool_use must
+// be immediately followed by a user message containing a tool_result with the
+// matching ID. Conversations replayed from session storage often violate this
+// (e.g. when a tool call was made but the agent crashed before recording the
+// result), and Anthropic rejects the entire request with a 400 if we don't
+// scrub the orphans before sending. The function should:
+//   - never alter messages that don't carry tool_use
+//   - drop tool_use blocks whose IDs aren't present in the next user message
+//   - drop the whole assistant message if scrubbing leaves it empty
+//   - keep the message when at least one tool_use survives or other content
+//     (e.g. text) was present alongside the orphans
+func TestRepairMessageHistory(t *testing.T) {
+	textBlock := func(s string) anthropic.ContentBlockParamUnion {
+		return anthropic.NewTextBlock(s)
+	}
+	toolUseBlock := func(id string) anthropic.ContentBlockParamUnion {
+		return anthropic.ContentBlockParamUnion{
+			OfToolUse: &anthropic.ToolUseBlockParam{ID: id},
+		}
+	}
+	toolResultBlock := func(id string) anthropic.ContentBlockParamUnion {
+		return anthropic.ContentBlockParamUnion{
+			OfToolResult: &anthropic.ToolResultBlockParam{ToolUseID: id},
+		}
+	}
+
+	cases := []struct {
+		name           string
+		messages       []anthropic.MessageParam
+		wantLen        int
+		wantSurviving  []string // tool_use IDs that must remain in the first message
+		wantNotPresent []string // tool_use IDs that must NOT remain anywhere
+	}{
+		{
+			name:     "empty input is returned untouched",
+			messages: []anthropic.MessageParam{},
+			wantLen:  0,
+		},
+		{
+			name: "messages without tool_use are passed through verbatim",
+			messages: []anthropic.MessageParam{
+				{Role: anthropic.MessageParamRoleUser, Content: []anthropic.ContentBlockParamUnion{textBlock("hi")}},
+				{Role: anthropic.MessageParamRoleAssistant, Content: []anthropic.ContentBlockParamUnion{textBlock("hello")}},
+			},
+			wantLen: 2,
+		},
+		{
+			name: "tool_use without any following message is dropped entirely",
+			messages: []anthropic.MessageParam{
+				{
+					Role:    anthropic.MessageParamRoleAssistant,
+					Content: []anthropic.ContentBlockParamUnion{toolUseBlock("orphan_1")},
+				},
+			},
+			wantLen:        0,
+			wantNotPresent: []string{"orphan_1"},
+		},
+		{
+			name: "tool_use with matching tool_result is preserved",
+			messages: []anthropic.MessageParam{
+				{
+					Role:    anthropic.MessageParamRoleAssistant,
+					Content: []anthropic.ContentBlockParamUnion{toolUseBlock("matched")},
+				},
+				{
+					Role:    anthropic.MessageParamRoleUser,
+					Content: []anthropic.ContentBlockParamUnion{toolResultBlock("matched")},
+				},
+			},
+			wantLen:       2,
+			wantSurviving: []string{"matched"},
+		},
+		{
+			name: "mixed assistant message keeps text plus matched tool_use, drops orphan",
+			messages: []anthropic.MessageParam{
+				{
+					Role: anthropic.MessageParamRoleAssistant,
+					Content: []anthropic.ContentBlockParamUnion{
+						toolUseBlock("matched"),
+						toolUseBlock("orphan"),
+						textBlock("ran the tool"),
+					},
+				},
+				{
+					Role:    anthropic.MessageParamRoleUser,
+					Content: []anthropic.ContentBlockParamUnion{toolResultBlock("matched")},
+				},
+			},
+			wantLen:        2,
+			wantSurviving:  []string{"matched"},
+			wantNotPresent: []string{"orphan"},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := repairMessageHistory(c.messages)
+
+			if len(got) != c.wantLen {
+				t.Fatalf("len = %d, want %d", len(got), c.wantLen)
+			}
+
+			if c.wantLen == 0 {
+				return
+			}
+
+			survivingIDs := extractToolUseIDs(got[0])
+			survivingSet := toSet(survivingIDs)
+
+			for _, id := range c.wantSurviving {
+				if !survivingSet[id] {
+					t.Errorf("expected tool_use %q to survive, got %v", id, survivingIDs)
+				}
+			}
+			for _, id := range c.wantNotPresent {
+				if survivingSet[id] {
+					t.Errorf("expected tool_use %q to be removed, got %v", id, survivingIDs)
+				}
+			}
+		})
+	}
+}
+
+func toSet(ss []string) map[string]bool {
+	out := make(map[string]bool, len(ss))
+	for _, s := range ss {
+		out[s] = true
+	}
+	return out
+}

--- a/genai/anthropic/tools_test.go
+++ b/genai/anthropic/tools_test.go
@@ -1,0 +1,210 @@
+// Copyright 2025 achetronic
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package anthropic
+
+import (
+	"reflect"
+	"testing"
+
+	"google.golang.org/genai"
+)
+
+// convertTools must produce schemas that satisfy Anthropic's JSON Schema
+// validator, which strictly follows draft 2020-12. The genai SDK emits type
+// names in upper-case (e.g. "ARRAY", "STRING"); leaving those upper-case in
+// the wire payload causes Anthropic to reject the entire request with
+// "tools.N.custom.input_schema: JSON schema is invalid". This test pins down
+// the contract: every "type" field, at every depth, lands in lower-case.
+//
+// Issue: https://github.com/achetronic/adk-utils-go/issues/15
+func TestConvertTools_LowercasesNestedSchemaTypes(t *testing.T) {
+	m := &Model{modelName: "test-model"}
+
+	tools := []*genai.Tool{
+		{
+			FunctionDeclarations: []*genai.FunctionDeclaration{
+				{
+					Name: "test_tool",
+					Parameters: &genai.Schema{
+						Type: genai.TypeObject,
+						Properties: map[string]*genai.Schema{
+							"artifact_names": {
+								Type:  genai.TypeArray,
+								Items: &genai.Schema{Type: genai.TypeString},
+							},
+							"options": {
+								Type: genai.TypeObject,
+								Properties: map[string]*genai.Schema{
+									"deep": {
+										Type:  genai.TypeArray,
+										Items: &genai.Schema{Type: genai.TypeInteger},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	converted, err := m.convertTools(tools)
+	if err != nil {
+		t.Fatalf("convertTools error: %v", err)
+	}
+	if len(converted) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(converted))
+	}
+	tool := converted[0].OfTool
+	if tool == nil {
+		t.Fatalf("expected OfTool to be set")
+	}
+
+	props, ok := tool.InputSchema.Properties.(map[string]any)
+	if !ok {
+		t.Fatalf("Properties is %T, want map[string]any", tool.InputSchema.Properties)
+	}
+
+	wantType := func(t *testing.T, m map[string]any, want string, where string) {
+		t.Helper()
+		got, ok := m["type"].(string)
+		if !ok {
+			t.Errorf("%s: missing or non-string \"type\" field, got %T", where, m["type"])
+			return
+		}
+		if got != want {
+			t.Errorf("%s: type = %q, want %q", where, got, want)
+		}
+	}
+
+	artifactNames := props["artifact_names"].(map[string]any)
+	wantType(t, artifactNames, "array", "artifact_names")
+	wantType(t, artifactNames["items"].(map[string]any), "string", "artifact_names.items")
+
+	options := props["options"].(map[string]any)
+	wantType(t, options, "object", "options")
+	deep := options["properties"].(map[string]any)["deep"].(map[string]any)
+	wantType(t, deep, "array", "options.properties.deep")
+	wantType(t, deep["items"].(map[string]any), "integer", "options.properties.deep.items")
+}
+
+// convertTools also propagates "required" from the genai schema. After the
+// JSON round-trip required arrives as []interface{}; the adapter must still
+// flatten it back to []string for the Anthropic SDK's strict typing.
+func TestConvertTools_PreservesRequired(t *testing.T) {
+	m := &Model{modelName: "test-model"}
+
+	tools := []*genai.Tool{{
+		FunctionDeclarations: []*genai.FunctionDeclaration{{
+			Name: "with_required",
+			Parameters: &genai.Schema{
+				Type:     genai.TypeObject,
+				Required: []string{"artifact_names", "kind"},
+				Properties: map[string]*genai.Schema{
+					"artifact_names": {Type: genai.TypeArray, Items: &genai.Schema{Type: genai.TypeString}},
+					"kind":           {Type: genai.TypeString},
+				},
+			},
+		}},
+	}}
+
+	got, err := m.convertTools(tools)
+	if err != nil {
+		t.Fatalf("convertTools error: %v", err)
+	}
+
+	required := got[0].OfTool.InputSchema.Required
+	if len(required) != 2 {
+		t.Fatalf("Required = %v, want 2 entries", required)
+	}
+	want := map[string]bool{"artifact_names": true, "kind": true}
+	for _, r := range required {
+		if !want[r] {
+			t.Errorf("unexpected required field %q", r)
+		}
+	}
+}
+
+// lowercaseTypes must walk the entire schema graph regardless of how deep
+// types are nested. We exercise object properties, array items, and the
+// awkward-but-legal case of nested arrays-of-objects-of-arrays. Anything that
+// isn't a "type" key must be left untouched (we don't want to rewrite enum
+// values that happen to be strings, for example).
+func TestLowercaseTypes(t *testing.T) {
+	cases := []struct {
+		name string
+		in   map[string]any
+		want map[string]any
+	}{
+		{
+			name: "root only",
+			in:   map[string]any{"type": "OBJECT"},
+			want: map[string]any{"type": "object"},
+		},
+		{
+			name: "nested object properties",
+			in: map[string]any{
+				"type": "OBJECT",
+				"properties": map[string]any{
+					"name": map[string]any{"type": "STRING"},
+				},
+			},
+			want: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"name": map[string]any{"type": "string"},
+				},
+			},
+		},
+		{
+			name: "array of objects",
+			in: map[string]any{
+				"type": "ARRAY",
+				"items": []any{
+					map[string]any{"type": "STRING"},
+					map[string]any{"type": "INTEGER"},
+				},
+			},
+			want: map[string]any{
+				"type": "array",
+				"items": []any{
+					map[string]any{"type": "string"},
+					map[string]any{"type": "integer"},
+				},
+			},
+		},
+		{
+			name: "leaves non-type strings alone",
+			in: map[string]any{
+				"type":        "STRING",
+				"description": "DO NOT TOUCH ME",
+				"enum":        []any{"FOO", "BAR"},
+			},
+			want: map[string]any{
+				"type":        "string",
+				"description": "DO NOT TOUCH ME",
+				"enum":        []any{"FOO", "BAR"},
+			},
+		},
+		{
+			name: "non-string type values are left alone",
+			in:   map[string]any{"type": 42},
+			want: map[string]any{"type": 42},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			lowercaseTypes(c.in)
+			if !reflect.DeepEqual(c.in, c.want) {
+				t.Errorf("after lowercaseTypes:\n got = %#v\nwant = %#v", c.in, c.want)
+			}
+		})
+	}
+}

--- a/genai/anthropic/utils_test.go
+++ b/genai/anthropic/utils_test.go
@@ -1,0 +1,209 @@
+// Copyright 2025 achetronic
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package anthropic
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"google.golang.org/genai"
+)
+
+// convertRoleToAnthropic must default unknown roles to "user" so we never emit
+// an Anthropic message with an undefined role enum, which would be rejected by
+// the SDK on marshal.
+func TestConvertRoleToAnthropic(t *testing.T) {
+	cases := []struct {
+		role string
+		want anthropic.MessageParamRole
+	}{
+		{"user", anthropic.MessageParamRoleUser},
+		{"model", anthropic.MessageParamRoleAssistant},
+		{"", anthropic.MessageParamRoleUser},
+		{"system", anthropic.MessageParamRoleUser},
+	}
+
+	for _, c := range cases {
+		t.Run(c.role, func(t *testing.T) {
+			if got := convertRoleToAnthropic(c.role); got != c.want {
+				t.Errorf("convertRoleToAnthropic(%q) = %q, want %q", c.role, got, c.want)
+			}
+		})
+	}
+}
+
+// convertStopReason maps Anthropic's discrete stop reasons to genai's enum.
+// Both ToolUse and StopSequence collapse to FinishReasonStop on purpose:
+// downstream callers don't differentiate, and treating them as anything other
+// than "stopped cleanly" would cause spurious retry loops.
+func TestConvertStopReason(t *testing.T) {
+	cases := []struct {
+		name   string
+		reason anthropic.StopReason
+		want   genai.FinishReason
+	}{
+		{"end_turn", anthropic.StopReasonEndTurn, genai.FinishReasonStop},
+		{"max_tokens", anthropic.StopReasonMaxTokens, genai.FinishReasonMaxTokens},
+		{"stop_sequence", anthropic.StopReasonStopSequence, genai.FinishReasonStop},
+		{"tool_use", anthropic.StopReasonToolUse, genai.FinishReasonStop},
+		{"unknown_value", anthropic.StopReason("garbage"), genai.FinishReasonUnspecified},
+		{"empty", anthropic.StopReason(""), genai.FinishReasonUnspecified},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := convertStopReason(c.reason); got != c.want {
+				t.Errorf("convertStopReason(%q) = %v, want %v", c.reason, got, c.want)
+			}
+		})
+	}
+}
+
+// convertToolInputToRaw guards the wire format we send for tool_use.input.
+// Anthropic requires a JSON object literal — never null, never an empty
+// payload — so we always normalise to "{}" when the caller hands us nil,
+// empty, or null-marshaling values. Anything that already round-trips as
+// valid JSON is passed through verbatim to avoid losing precision.
+func TestConvertToolInputToRaw(t *testing.T) {
+	cases := []struct {
+		name  string
+		input any
+		want  string
+	}{
+		{"nil", nil, "{}"},
+		{"nil typed map", (map[string]any)(nil), "{}"},
+		{"empty map", map[string]any{}, "{}"},
+		{"populated map", map[string]any{"k": "v"}, `{"k":"v"}`},
+		{"empty raw message falls back to default", json.RawMessage(""), "{}"},
+		{"raw message passes through", json.RawMessage(`{"a":1}`), `{"a":1}`},
+		{"struct gets marshaled", struct {
+			Foo string `json:"foo"`
+		}{Foo: "bar"}, `{"foo":"bar"}`},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := string(convertToolInputToRaw(c.input))
+			if got != c.want {
+				t.Errorf("convertToolInputToRaw() = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+// convertToolInput is the inverse direction: raw payloads coming back from the
+// model get normalised into a Go map for genai.FunctionCall.Args. We assert on
+// equivalence (reflect.DeepEqual) instead of byte-for-byte JSON because the
+// numeric type after Unmarshal is float64, which is fine for downstream callers.
+func TestConvertToolInput(t *testing.T) {
+	cases := []struct {
+		name  string
+		input any
+		want  map[string]any
+	}{
+		{"nil", nil, map[string]any{}},
+		{"already a map", map[string]any{"a": 1}, map[string]any{"a": 1}},
+		{"raw message", json.RawMessage(`{"b":2}`), map[string]any{"b": float64(2)}},
+		{"unmarshalable input falls back to empty", make(chan int), map[string]any{}},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := convertToolInput(c.input)
+			if !reflect.DeepEqual(got, c.want) {
+				t.Errorf("convertToolInput() = %#v, want %#v", got, c.want)
+			}
+		})
+	}
+}
+
+// extractTextFromContent must concatenate only the text-bearing parts and
+// preserve their order. Non-text parts (inline data, function calls/responses)
+// must be skipped entirely so we don't leak placeholders into prompts.
+func TestExtractTextFromContent(t *testing.T) {
+	cases := []struct {
+		name    string
+		content *genai.Content
+		want    string
+	}{
+		{"nil content", nil, ""},
+		{"no parts", &genai.Content{Parts: []*genai.Part{}}, ""},
+		{"single text", &genai.Content{Parts: []*genai.Part{{Text: "hello"}}}, "hello"},
+		{
+			name: "multiple text parts joined with newline",
+			content: &genai.Content{Parts: []*genai.Part{
+				{Text: "hello"},
+				{Text: "world"},
+			}},
+			want: "hello\nworld",
+		},
+		{
+			name: "non-text parts are skipped",
+			content: &genai.Content{Parts: []*genai.Part{
+				{Text: "before"},
+				{InlineData: &genai.Blob{MIMEType: "image/png"}},
+				{Text: "after"},
+			}},
+			want: "before\nafter",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := extractTextFromContent(c.content); got != c.want {
+				t.Errorf("extractTextFromContent() = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+// sanitizeToolID guarantees Anthropic's regex constraint: ^[a-zA-Z0-9_-]+$.
+// Valid IDs must pass through verbatim (so callers can reverse-correlate
+// requests/responses); invalid IDs must be deterministically rewritten to a
+// "toolu_" prefix plus 32 hex chars (16 bytes of SHA-256). We assert on the
+// invariants rather than the exact length so the test survives any future
+// SDK-level changes that don't break the contract.
+func TestSanitizeToolID(t *testing.T) {
+	const validIDPrefix = "toolu_"
+
+	t.Run("valid id passes through", func(t *testing.T) {
+		want := "tool_call-123_abc"
+		if got := sanitizeToolID(want); got != want {
+			t.Errorf("sanitizeToolID(%q) = %q, want passthrough", want, got)
+		}
+	})
+
+	t.Run("invalid id gets rewritten deterministically", func(t *testing.T) {
+		invalid := "invalid/tool:id with spaces"
+
+		first := sanitizeToolID(invalid)
+		second := sanitizeToolID(invalid)
+
+		if first != second {
+			t.Errorf("sanitizeToolID is non-deterministic: %q vs %q", first, second)
+		}
+		if !strings.HasPrefix(first, validIDPrefix) {
+			t.Errorf("sanitizeToolID(%q) = %q, want %q prefix", invalid, first, validIDPrefix)
+		}
+		if !anthropicToolIDPattern.MatchString(first) {
+			t.Errorf("sanitizeToolID(%q) = %q, does not match Anthropic ID pattern", invalid, first)
+		}
+	})
+
+	t.Run("different inputs produce different outputs", func(t *testing.T) {
+		a := sanitizeToolID("foo!")
+		b := sanitizeToolID("bar?")
+		if a == b {
+			t.Errorf("expected different sanitized IDs, both produced %q", a)
+		}
+	})
+}

--- a/genai/openai/core_test.go
+++ b/genai/openai/core_test.go
@@ -1,0 +1,287 @@
+// Copyright 2025 achetronic
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package openai
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"google.golang.org/genai"
+)
+
+// convertSchema is the strongly-typed path used by ResponseSchema. We assert
+// on structural equality (a map[string]any tree) rather than serialised JSON
+// because Go's json.Marshal happens to sort map keys alphabetically — relying
+// on that ordering implicitly would couple the test to an implementation
+// detail of the standard library that future Go versions don't have to
+// preserve.
+func TestConvertSchema(t *testing.T) {
+	cases := []struct {
+		name   string
+		schema *genai.Schema
+		want   map[string]any
+	}{
+		{
+			name:   "nil schema yields a default empty object",
+			schema: nil,
+			want: map[string]any{
+				"type":       "object",
+				"properties": map[string]any{},
+			},
+		},
+		{
+			name: "primitive with description",
+			schema: &genai.Schema{
+				Type:        genai.TypeString,
+				Description: "a string",
+			},
+			want: map[string]any{
+				"type":        "string",
+				"description": "a string",
+			},
+		},
+		{
+			name: "object with required and nested integer property",
+			schema: &genai.Schema{
+				Type:     genai.TypeObject,
+				Required: []string{"a"},
+				Properties: map[string]*genai.Schema{
+					"a": {Type: genai.TypeInteger},
+				},
+			},
+			want: map[string]any{
+				"type":     "object",
+				"required": []string{"a"},
+				"properties": map[string]any{
+					"a": map[string]any{"type": "integer"},
+				},
+			},
+		},
+		{
+			name: "array with item schema",
+			schema: &genai.Schema{
+				Type:  genai.TypeArray,
+				Items: &genai.Schema{Type: genai.TypeString},
+			},
+			want: map[string]any{
+				"type":  "array",
+				"items": map[string]any{"type": "string"},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := convertSchema(c.schema)
+			if err != nil {
+				t.Fatalf("convertSchema() error = %v", err)
+			}
+			if !reflect.DeepEqual(got, c.want) {
+				t.Errorf("convertSchema() = %#v\nwant %#v", got, c.want)
+			}
+		})
+	}
+}
+
+// convertToFunctionParams handles user-provided tool schemas of any shape:
+// genai.Schema, raw map[string]any, or anything that round-trips through
+// JSON. Whichever path is taken, the resulting schema must:
+//   - have all "type" fields lower-cased (Anthropic-style validation now
+//     applies to recent OpenAI endpoints too)
+//   - never produce an "object" without a "properties" field, because OpenAI
+//     rejects tool definitions that omit it
+func TestConvertToFunctionParams(t *testing.T) {
+	cases := []struct {
+		name string
+		in   any
+		want map[string]any
+	}{
+		{
+			name: "uppercase types from genai schema get normalised and properties injected",
+			in: map[string]any{
+				"type": "OBJECT",
+				"properties": map[string]any{
+					"name": map[string]any{"type": "STRING"},
+					"items": map[string]any{
+						"type":  "ARRAY",
+						"items": map[string]any{"type": "OBJECT"}, // missing properties
+					},
+				},
+			},
+			want: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"name": map[string]any{"type": "string"},
+					"items": map[string]any{
+						"type": "array",
+						"items": map[string]any{
+							"type":       "object",
+							"properties": map[string]any{},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "nil input returns nil",
+			in:   nil,
+			want: nil,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := convertToFunctionParams(c.in)
+			if c.want == nil {
+				if got != nil {
+					t.Errorf("convertToFunctionParams() = %#v, want nil", got)
+				}
+				return
+			}
+			gotMap := map[string]any(got)
+			if !reflect.DeepEqual(gotMap, c.want) {
+				t.Errorf("convertToFunctionParams() = %#v\nwant %#v", gotMap, c.want)
+			}
+		})
+	}
+}
+
+// lowercaseTypes walks the schema graph and lowercases every "type" string
+// it finds, regardless of nesting. We test:
+//   - the trivial root case
+//   - traversal through "properties" maps
+//   - traversal through "items" lists (legal in JSON Schema for tuple-style
+//     arrays)
+//   - that non-string "type" values and unrelated string fields are left
+//     alone, so we don't mangle enum values that happen to contain capitals
+func TestLowercaseTypes(t *testing.T) {
+	cases := []struct {
+		name string
+		in   map[string]any
+		want map[string]any
+	}{
+		{
+			name: "root only",
+			in:   map[string]any{"type": "OBJECT"},
+			want: map[string]any{"type": "object"},
+		},
+		{
+			name: "deeply nested",
+			in: map[string]any{
+				"type": "OBJECT",
+				"properties": map[string]any{
+					"name": map[string]any{"type": "STRING"},
+					"tags": map[string]any{
+						"type":  "ARRAY",
+						"items": map[string]any{"type": "STRING"},
+					},
+				},
+			},
+			want: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"name": map[string]any{"type": "string"},
+					"tags": map[string]any{
+						"type":  "array",
+						"items": map[string]any{"type": "string"},
+					},
+				},
+			},
+		},
+		{
+			name: "tuple-style array items",
+			in: map[string]any{
+				"type": "ARRAY",
+				"items": []any{
+					map[string]any{"type": "STRING"},
+					map[string]any{"type": "INTEGER"},
+				},
+			},
+			want: map[string]any{
+				"type": "array",
+				"items": []any{
+					map[string]any{"type": "string"},
+					map[string]any{"type": "integer"},
+				},
+			},
+		},
+		{
+			name: "non-type fields untouched",
+			in: map[string]any{
+				"type":        "STRING",
+				"description": "DO NOT TOUCH",
+				"enum":        []any{"FOO", "BAR"},
+			},
+			want: map[string]any{
+				"type":        "string",
+				"description": "DO NOT TOUCH",
+				"enum":        []any{"FOO", "BAR"},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			lowercaseTypes(c.in)
+			if !reflect.DeepEqual(c.in, c.want) {
+				t.Errorf("after lowercaseTypes:\n got = %#v\nwant = %#v", c.in, c.want)
+			}
+		})
+	}
+}
+
+// normalizeToolCallID hashes IDs longer than OpenAI's 40-char limit and
+// remembers the mapping so denormalize can recover the original. Short IDs
+// pass through untouched. The exact length of the shortened ID is part of
+// the contract — OpenAI rejects anything beyond 40 chars — so we assert on
+// the boundary explicitly.
+func TestNormalizeToolCallID(t *testing.T) {
+	const limit = 40
+
+	t.Run("short ID passes through", func(t *testing.T) {
+		m := newModelForTest()
+		const id = "call_short"
+		if got := m.normalizeToolCallID(id); got != id {
+			t.Errorf("normalizeToolCallID(%q) = %q, want passthrough", id, got)
+		}
+	})
+
+	t.Run("long ID is shortened deterministically and is reversible", func(t *testing.T) {
+		m := newModelForTest()
+		long := "call_" + strings.Repeat("x", 100)
+
+		first := m.normalizeToolCallID(long)
+		second := m.normalizeToolCallID(long)
+
+		if first != second {
+			t.Errorf("normalizeToolCallID is non-deterministic: %q vs %q", first, second)
+		}
+		if len(first) > limit {
+			t.Errorf("normalizeToolCallID = %q (len %d), want <= %d", first, len(first), limit)
+		}
+		if !strings.HasPrefix(first, "tc_") {
+			t.Errorf("normalizeToolCallID = %q, want \"tc_\" prefix", first)
+		}
+		if got := m.denormalizeToolCallID(first); got != long {
+			t.Errorf("denormalizeToolCallID(%q) = %q, want original %q", first, got, long)
+		}
+	})
+
+	t.Run("denormalize unknown ID returns input untouched", func(t *testing.T) {
+		m := newModelForTest()
+		if got := m.denormalizeToolCallID("never_seen"); got != "never_seen" {
+			t.Errorf("denormalizeToolCallID() = %q, want passthrough", got)
+		}
+	})
+}
+
+func newModelForTest() *Model {
+	return &Model{toolCallIDMap: make(map[string]string)}
+}

--- a/genai/openai/messages_test.go
+++ b/genai/openai/messages_test.go
@@ -1,0 +1,371 @@
+// Copyright 2025 achetronic
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package openai
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/openai/openai-go/v3"
+	"google.golang.org/genai"
+)
+
+// convertContentToMessages bridges ADK Content into OpenAI's per-role message
+// shapes. The non-trivial bit is that a single Content can produce multiple
+// OpenAI messages: function responses must become tool messages of their own,
+// while text/media/tool calls coalesce into a single role message. This test
+// pins down the resulting message shape (count, roles, payload) without
+// reaching into the SDK's union internals — we use a small kind() helper that
+// reads which OfXxx pointer is set.
+func TestConvertContentToMessages(t *testing.T) {
+	cases := []struct {
+		name      string
+		content   *genai.Content
+		wantKinds []string // ordered "role" discriminators
+		assert    func(t *testing.T, msgs []openai.ChatCompletionMessageParamUnion)
+	}{
+		{
+			name: "user text becomes a single user message",
+			content: &genai.Content{
+				Role:  "user",
+				Parts: []*genai.Part{{Text: "hello"}},
+			},
+			wantKinds: []string{"user"},
+		},
+		{
+			name: "model text becomes an assistant message",
+			content: &genai.Content{
+				Role:  "model",
+				Parts: []*genai.Part{{Text: "hi back"}},
+			},
+			wantKinds: []string{"assistant"},
+		},
+		{
+			name: "function response becomes a standalone tool message preserving the (normalised) ID",
+			content: &genai.Content{
+				Role: "user",
+				Parts: []*genai.Part{
+					{FunctionResponse: &genai.FunctionResponse{
+						ID:       "call_short",
+						Response: map[string]any{"ok": true},
+					}},
+				},
+			},
+			wantKinds: []string{"tool"},
+			assert: func(t *testing.T, msgs []openai.ChatCompletionMessageParamUnion) {
+				if got := msgs[0].OfTool.ToolCallID; got != "call_short" {
+					t.Errorf("ToolCallID = %q, want %q", got, "call_short")
+				}
+				content := msgs[0].OfTool.Content.OfString.Value
+				if !strings.Contains(content, `"ok":true`) {
+					t.Errorf("tool content = %q, expected to contain serialised response", content)
+				}
+			},
+		},
+		{
+			name: "model text plus function call coalesce into a single assistant message",
+			content: &genai.Content{
+				Role: "model",
+				Parts: []*genai.Part{
+					{Text: "calling tool"},
+					{FunctionCall: &genai.FunctionCall{
+						ID:   "call_xyz",
+						Name: "do_thing",
+						Args: map[string]any{"foo": "bar"},
+					}},
+				},
+			},
+			wantKinds: []string{"assistant"},
+			assert: func(t *testing.T, msgs []openai.ChatCompletionMessageParamUnion) {
+				assistant := msgs[0].OfAssistant
+				if assistant == nil {
+					t.Fatalf("expected assistant message")
+				}
+				if got := assistant.Content.OfString.Value; got != "calling tool" {
+					t.Errorf("assistant text = %q, want \"calling tool\"", got)
+				}
+				if len(assistant.ToolCalls) != 1 {
+					t.Fatalf("expected 1 tool call, got %d", len(assistant.ToolCalls))
+				}
+				tc := assistant.ToolCalls[0].OfFunction
+				if tc == nil {
+					t.Fatalf("expected function tool call")
+				}
+				if tc.ID != "call_xyz" {
+					t.Errorf("tool call ID = %q, want %q", tc.ID, "call_xyz")
+				}
+				if tc.Function.Name != "do_thing" {
+					t.Errorf("function name = %q, want %q", tc.Function.Name, "do_thing")
+				}
+				if !strings.Contains(tc.Function.Arguments, `"foo":"bar"`) {
+					t.Errorf("arguments = %q, want serialised map", tc.Function.Arguments)
+				}
+			},
+		},
+		{
+			name: "user text plus inline image yields a multi-part user message",
+			content: &genai.Content{
+				Role: "user",
+				Parts: []*genai.Part{
+					{Text: "describe this"},
+					{InlineData: &genai.Blob{MIMEType: "image/png", Data: []byte("fakepng")}},
+				},
+			},
+			wantKinds: []string{"user"},
+			assert: func(t *testing.T, msgs []openai.ChatCompletionMessageParamUnion) {
+				user := msgs[0].OfUser
+				if user == nil {
+					t.Fatalf("expected user message")
+				}
+				parts := user.Content.OfArrayOfContentParts
+				if len(parts) != 2 {
+					t.Fatalf("expected 2 content parts (text + image), got %d", len(parts))
+				}
+				if parts[0].OfText == nil || parts[0].OfText.Text != "describe this" {
+					t.Errorf("first part should be the text, got %#v", parts[0])
+				}
+				if parts[1].OfImageURL == nil {
+					t.Errorf("second part should be the image, got %#v", parts[1])
+				}
+			},
+		},
+		{
+			name: "function response and assistant call in the same content produce two messages",
+			content: &genai.Content{
+				Role: "model",
+				Parts: []*genai.Part{
+					{FunctionResponse: &genai.FunctionResponse{ID: "tool_1", Response: map[string]any{"k": "v"}}},
+					{Text: "all done"},
+				},
+			},
+			wantKinds: []string{"tool", "assistant"},
+		},
+		{
+			name: "content with no usable parts produces no messages",
+			content: &genai.Content{
+				Role:  "user",
+				Parts: []*genai.Part{{}}, // empty Part
+			},
+			wantKinds: nil,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			m := newModelForTest()
+			got, err := m.convertContentToMessages(c.content)
+			if err != nil {
+				t.Fatalf("convertContentToMessages error: %v", err)
+			}
+
+			gotKinds := messageRoles(got)
+			if !equalStringSlices(gotKinds, c.wantKinds) {
+				t.Fatalf("message kinds = %v, want %v", gotKinds, c.wantKinds)
+			}
+
+			if c.assert != nil {
+				c.assert(t, got)
+			}
+		})
+	}
+}
+
+// convertContentToMessages must propagate function call IDs through the
+// normalisation layer so OpenAI sees a valid tool_call_id (≤40 chars). The
+// inverse mapping must be discoverable through denormalizeToolCallID, which
+// callers use when correlating a tool result back to the original ADK ID.
+func TestConvertContentToMessages_NormalisesLongToolIDs(t *testing.T) {
+	m := newModelForTest()
+	long := "call_" + strings.Repeat("z", 100)
+
+	content := &genai.Content{
+		Role: "model",
+		Parts: []*genai.Part{
+			{FunctionCall: &genai.FunctionCall{ID: long, Name: "tool", Args: map[string]any{}}},
+		},
+	}
+
+	msgs, err := m.convertContentToMessages(content)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(msgs))
+	}
+
+	tc := msgs[0].OfAssistant.ToolCalls[0].OfFunction
+	if len(tc.ID) > maxToolCallIDLength {
+		t.Errorf("tool_call_id length = %d, want <= %d", len(tc.ID), maxToolCallIDLength)
+	}
+	if got := m.denormalizeToolCallID(tc.ID); got != long {
+		t.Errorf("denormalize round-trip failed: got %q, want %q", got, long)
+	}
+}
+
+// buildRoleMessage routes texts/media/tool calls to the right role-specific
+// builder. Anything outside {user, model, system} (after convertRole) must
+// return nil so the caller can decide to drop the turn rather than send a
+// message with an undefined role.
+func TestBuildRoleMessage(t *testing.T) {
+	cases := []struct {
+		name      string
+		role      string
+		texts     []string
+		toolCalls int
+		wantKind  string
+	}{
+		{"user role builds user message", "user", []string{"hi"}, 0, "user"},
+		{"model role builds assistant message", "model", []string{"hello"}, 0, "assistant"},
+		{"system role builds system message", "system", []string{"prompt"}, 0, "system"},
+		{"unknown role returns nil", "tool", []string{"x"}, 0, ""},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			m := newModelForTest()
+			toolCalls := make([]openai.ChatCompletionMessageToolCallUnionParam, c.toolCalls)
+			got := m.buildRoleMessage(c.role, c.texts, nil, toolCalls)
+
+			if c.wantKind == "" {
+				if got != nil {
+					t.Errorf("expected nil for unknown role %q, got %#v", c.role, got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("expected %s message, got nil", c.wantKind)
+			}
+			if kind := messageKind(*got); kind != c.wantKind {
+				t.Errorf("kind = %q, want %q", kind, c.wantKind)
+			}
+		})
+	}
+}
+
+// buildAssistantMessage never returns nil even when both texts and toolCalls
+// are empty: callers depend on a non-nil pointer to inspect the union
+// discriminator. The text content slot must remain unset when no texts are
+// passed, otherwise OpenAI will see an empty string instead of "no content"
+// and may refuse to dispatch a tool-only turn.
+func TestBuildAssistantMessage(t *testing.T) {
+	cases := []struct {
+		name      string
+		texts     []string
+		toolCalls int
+		wantText  string
+		wantTools int
+	}{
+		{"text only", []string{"hi"}, 0, "hi", 0},
+		{"tool calls only", nil, 2, "", 2},
+		{"text + tool calls", []string{"a", "b"}, 1, "a\nb", 1},
+		{"empty produces empty assistant", nil, 0, "", 0},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			toolCalls := make([]openai.ChatCompletionMessageToolCallUnionParam, c.toolCalls)
+			got := buildAssistantMessage(c.texts, toolCalls)
+			if got == nil {
+				t.Fatalf("buildAssistantMessage returned nil")
+			}
+			a := got.OfAssistant
+			if a == nil {
+				t.Fatalf("OfAssistant = nil")
+			}
+			if got := a.Content.OfString.Value; got != c.wantText {
+				t.Errorf("text = %q, want %q", got, c.wantText)
+			}
+			if len(a.ToolCalls) != c.wantTools {
+				t.Errorf("tool calls = %d, want %d", len(a.ToolCalls), c.wantTools)
+			}
+		})
+	}
+}
+
+// buildUserMessage takes the simple path (string content) when there are no
+// media parts and switches to the multi-part array shape only when media is
+// present. This split matters: the simple path is required for any provider
+// that doesn't support multi-modal input (Ollama, older OpenAI-compatible
+// servers).
+func TestBuildUserMessage(t *testing.T) {
+	t.Run("text only takes the simple string path", func(t *testing.T) {
+		got := buildUserMessage([]string{"hello", "world"}, nil)
+		if got.OfUser == nil {
+			t.Fatalf("OfUser = nil")
+		}
+		if v := got.OfUser.Content.OfString.Value; v != "hello\nworld" {
+			t.Errorf("string content = %q, want %q", v, "hello\nworld")
+		}
+		if got.OfUser.Content.OfArrayOfContentParts != nil {
+			t.Errorf("expected array path to be unused when no media")
+		}
+	})
+
+	t.Run("text plus media uses the array-of-parts path", func(t *testing.T) {
+		media := []openai.ChatCompletionContentPartUnionParam{
+			{OfImageURL: &openai.ChatCompletionContentPartImageParam{}},
+		}
+		got := buildUserMessage([]string{"caption"}, media)
+		parts := got.OfUser.Content.OfArrayOfContentParts
+		if len(parts) != 2 {
+			t.Fatalf("parts = %d, want 2", len(parts))
+		}
+		if parts[0].OfText == nil || parts[0].OfText.Text != "caption" {
+			t.Errorf("first part = %#v, want text \"caption\"", parts[0])
+		}
+		if parts[1].OfImageURL == nil {
+			t.Errorf("second part should be the image")
+		}
+	})
+}
+
+// messageRoles inspects the union to return per-message role discriminators
+// in order. Tests use this instead of fishing into the SDK's internals so
+// they remain stable across SDK refactors.
+func messageRoles(msgs []openai.ChatCompletionMessageParamUnion) []string {
+	if len(msgs) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(msgs))
+	for _, m := range msgs {
+		out = append(out, messageKind(m))
+	}
+	return out
+}
+
+func messageKind(m openai.ChatCompletionMessageParamUnion) string {
+	switch {
+	case m.OfUser != nil:
+		return "user"
+	case m.OfAssistant != nil:
+		return "assistant"
+	case m.OfSystem != nil:
+		return "system"
+	case m.OfTool != nil:
+		return "tool"
+	case m.OfDeveloper != nil:
+		return "developer"
+	case m.OfFunction != nil:
+		return "function"
+	default:
+		return "unknown"
+	}
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/genai/openai/openai.go
+++ b/genai/openai/openai.go
@@ -545,6 +545,8 @@ func convertToFunctionParams(params any) shared.FunctionParameters {
 		}
 	}
 
+	// Standardise types to lowercase for JSON schema compliance
+	lowercaseTypes(m)
 	// OpenAI requires "properties" for object types
 	ensureObjectProperties(m)
 
@@ -576,6 +578,26 @@ func ensureObjectProperties(schema map[string]any) {
 	// Process array items
 	if items, ok := schema["items"].(map[string]any); ok {
 		ensureObjectProperties(items)
+	}
+}
+
+// lowercaseTypes recursively traverses a JSON schema map and lowercases all "type" fields
+// to comply with standard JSON schema validation.
+func lowercaseTypes(m map[string]any) {
+	for k, v := range m {
+		if k == "type" {
+			if s, ok := v.(string); ok {
+				m[k] = strings.ToLower(s)
+			}
+		} else if vMap, ok := v.(map[string]any); ok {
+			lowercaseTypes(vMap)
+		} else if vList, ok := v.([]any); ok {
+			for _, item := range vList {
+				if itemMap, ok := item.(map[string]any); ok {
+					lowercaseTypes(itemMap)
+				}
+			}
+		}
 	}
 }
 

--- a/genai/openai/response_test.go
+++ b/genai/openai/response_test.go
@@ -1,0 +1,254 @@
+// Copyright 2025 achetronic
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package openai
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/shared"
+	"google.golang.org/genai"
+)
+
+// convertResponse rebuilds a genai.LLMResponse from the SDK's
+// ChatCompletion. The non-trivial cases are:
+//   - empty Choices must surface ErrNoChoicesInResponse so the caller can
+//     treat it as a hard failure (an "empty" response is undefined behaviour
+//     for OpenAI; better to fail loudly than to bubble up an empty turn)
+//   - both text and tool_calls in the same choice must coexist in the
+//     resulting Content (the order matters: text first, then tool calls,
+//     mirroring how the genai-side iteration consumes parts)
+//   - Args inside the function call must be JSON-decoded (parseJSONArgs),
+//     not passed through verbatim as a string
+func TestConvertResponse(t *testing.T) {
+	t.Run("empty choices returns ErrNoChoicesInResponse", func(t *testing.T) {
+		m := newModelForTest()
+		resp := &openai.ChatCompletion{}
+		_, err := m.convertResponse(resp)
+		if !errors.Is(err, ErrNoChoicesInResponse) {
+			t.Errorf("err = %v, want %v", err, ErrNoChoicesInResponse)
+		}
+	})
+
+	t.Run("text only response", func(t *testing.T) {
+		m := newModelForTest()
+		resp := &openai.ChatCompletion{
+			Choices: []openai.ChatCompletionChoice{{
+				Message:      openai.ChatCompletionMessage{Content: "hello"},
+				FinishReason: "stop",
+			}},
+			Usage: openai.CompletionUsage{PromptTokens: 1, CompletionTokens: 2, TotalTokens: 3},
+		}
+		got, err := m.convertResponse(resp)
+		if err != nil {
+			t.Fatalf("error: %v", err)
+		}
+		if !got.TurnComplete {
+			t.Errorf("TurnComplete = false, want true")
+		}
+		if got.FinishReason != genai.FinishReasonStop {
+			t.Errorf("FinishReason = %v, want Stop", got.FinishReason)
+		}
+		if got.Content == nil || len(got.Content.Parts) != 1 || got.Content.Parts[0].Text != "hello" {
+			t.Errorf("Content parts = %#v, want single text \"hello\"", got.Content)
+		}
+		if got.UsageMetadata == nil || got.UsageMetadata.TotalTokenCount != 3 {
+			t.Errorf("UsageMetadata = %#v, want TotalTokenCount=3", got.UsageMetadata)
+		}
+	})
+
+	t.Run("tool calls plus text", func(t *testing.T) {
+		m := newModelForTest()
+		resp := &openai.ChatCompletion{
+			Choices: []openai.ChatCompletionChoice{{
+				Message: openai.ChatCompletionMessage{
+					Content: "looking up",
+					ToolCalls: []openai.ChatCompletionMessageToolCallUnion{{
+						ID:   "call_42",
+						Type: "function",
+						Function: openai.ChatCompletionMessageFunctionToolCallFunction{
+							Name:      "search",
+							Arguments: `{"q":"weather"}`,
+						},
+					}},
+				},
+				FinishReason: "tool_calls",
+			}},
+		}
+		got, err := m.convertResponse(resp)
+		if err != nil {
+			t.Fatalf("error: %v", err)
+		}
+		if got.FinishReason != genai.FinishReasonStop {
+			t.Errorf("tool_calls finish should map to Stop, got %v", got.FinishReason)
+		}
+		if len(got.Content.Parts) != 2 {
+			t.Fatalf("expected 2 parts (text + call), got %d", len(got.Content.Parts))
+		}
+		if got.Content.Parts[0].Text != "looking up" {
+			t.Errorf("first part text = %q", got.Content.Parts[0].Text)
+		}
+		fc := got.Content.Parts[1].FunctionCall
+		if fc == nil {
+			t.Fatalf("expected FunctionCall on second part")
+		}
+		if fc.ID != "call_42" || fc.Name != "search" {
+			t.Errorf("FunctionCall = %#v, want id=call_42 name=search", fc)
+		}
+		if got, want := fc.Args, map[string]any{"q": "weather"}; !reflect.DeepEqual(got, want) {
+			t.Errorf("Args = %#v, want %#v", got, want)
+		}
+	})
+
+	t.Run("usage with zero total tokens is dropped", func(t *testing.T) {
+		m := newModelForTest()
+		resp := &openai.ChatCompletion{
+			Choices: []openai.ChatCompletionChoice{{
+				Message:      openai.ChatCompletionMessage{Content: "x"},
+				FinishReason: "stop",
+			}},
+			// Usage zero-valued: providers like Ollama don't always report tokens.
+		}
+		got, err := m.convertResponse(resp)
+		if err != nil {
+			t.Fatalf("error: %v", err)
+		}
+		if got.UsageMetadata != nil {
+			t.Errorf("UsageMetadata = %#v, want nil when no tokens reported", got.UsageMetadata)
+		}
+	})
+}
+
+// buildStreamFinalResponse mirrors convertResponse but reads from the
+// streaming Accumulator. It must be tolerant of an empty accumulator (no
+// choices yet) by returning an empty Content rather than panicking, and it
+// must always set TurnComplete=true and Partial=false because, by the time
+// it's called, the stream has already drained.
+func TestBuildStreamFinalResponse(t *testing.T) {
+	t.Run("empty accumulator returns an empty but valid response", func(t *testing.T) {
+		m := newModelForTest()
+		got := m.buildStreamFinalResponse(&openai.ChatCompletionAccumulator{})
+		if got == nil {
+			t.Fatalf("expected non-nil response")
+		}
+		if got.Partial {
+			t.Errorf("Partial = true, want false at end of stream")
+		}
+		if !got.TurnComplete {
+			t.Errorf("TurnComplete = false, want true at end of stream")
+		}
+		if got.Content == nil || len(got.Content.Parts) != 0 {
+			t.Errorf("Content = %#v, want empty parts", got.Content)
+		}
+	})
+
+	t.Run("populated accumulator collapses text and tool calls", func(t *testing.T) {
+		m := newModelForTest()
+		acc := &openai.ChatCompletionAccumulator{
+			ChatCompletion: openai.ChatCompletion{
+				Choices: []openai.ChatCompletionChoice{{
+					Message: openai.ChatCompletionMessage{
+						Content: "streamed",
+						ToolCalls: []openai.ChatCompletionMessageToolCallUnion{{
+							ID: "tc",
+							Function: openai.ChatCompletionMessageFunctionToolCallFunction{
+								Name:      "fn",
+								Arguments: `{"a":1}`,
+							},
+						}},
+					},
+					FinishReason: "stop",
+				}},
+				Usage: openai.CompletionUsage{TotalTokens: 9},
+			},
+		}
+		got := m.buildStreamFinalResponse(acc)
+		if got.FinishReason != genai.FinishReasonStop {
+			t.Errorf("FinishReason = %v, want Stop", got.FinishReason)
+		}
+		if len(got.Content.Parts) != 2 {
+			t.Fatalf("expected 2 parts, got %d", len(got.Content.Parts))
+		}
+		if got.UsageMetadata == nil || got.UsageMetadata.TotalTokenCount != 9 {
+			t.Errorf("UsageMetadata = %#v, want TotalTokenCount=9", got.UsageMetadata)
+		}
+	})
+}
+
+// convertUsageMetadata returns nil when the provider didn't report any
+// tokens (TotalTokens == 0). Ollama and a few self-hosted backends behave
+// this way, and surfacing a zeroed usage struct downstream poisons cost
+// reporting; we'd rather return nil so callers can detect the absence.
+func TestConvertUsageMetadata(t *testing.T) {
+	cases := []struct {
+		name   string
+		usage  openai.CompletionUsage
+		want   *genai.GenerateContentResponseUsageMetadata
+		wantOK bool
+	}{
+		{
+			name:   "no tokens reported returns nil",
+			usage:  openai.CompletionUsage{},
+			wantOK: false,
+		},
+		{
+			name:  "populated usage maps 1:1",
+			usage: openai.CompletionUsage{PromptTokens: 11, CompletionTokens: 22, TotalTokens: 33},
+			want: &genai.GenerateContentResponseUsageMetadata{
+				PromptTokenCount:     11,
+				CandidatesTokenCount: 22,
+				TotalTokenCount:      33,
+			},
+			wantOK: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := convertUsageMetadata(c.usage)
+			if !c.wantOK {
+				if got != nil {
+					t.Errorf("got = %#v, want nil", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("got nil, want %#v", c.want)
+			}
+			if !reflect.DeepEqual(got, c.want) {
+				t.Errorf("got = %#v, want %#v", got, c.want)
+			}
+		})
+	}
+}
+
+// convertThinkingLevel maps genai's three-level enum to OpenAI's reasoning
+// effort. Anything outside Low/High must default to Medium so callers can
+// safely use the enum's zero value (Unspecified) without inadvertently
+// disabling reasoning.
+func TestConvertThinkingLevel(t *testing.T) {
+	cases := []struct {
+		level genai.ThinkingLevel
+		want  shared.ReasoningEffort
+	}{
+		{genai.ThinkingLevelLow, shared.ReasoningEffortLow},
+		{genai.ThinkingLevelHigh, shared.ReasoningEffortHigh},
+		{genai.ThinkingLevel(""), shared.ReasoningEffortMedium},
+		{genai.ThinkingLevel("invalid"), shared.ReasoningEffortMedium},
+	}
+	for _, c := range cases {
+		t.Run(string(c.level), func(t *testing.T) {
+			if got := convertThinkingLevel(c.level); got != c.want {
+				t.Errorf("convertThinkingLevel(%q) = %q, want %q", c.level, got, c.want)
+			}
+		})
+	}
+}

--- a/genai/openai/tools_test.go
+++ b/genai/openai/tools_test.go
@@ -1,0 +1,253 @@
+// Copyright 2025 achetronic
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package openai
+
+import (
+	"strings"
+	"testing"
+
+	"google.golang.org/genai"
+)
+
+// convertTools is a thin wrapper around convertToFunctionParams. We exercise
+// it end-to-end here to lock in two contracts of the public method:
+//   - one OpenAI tool is emitted per genai FunctionDeclaration, regardless of
+//     how the caller groups them inside Tool aggregates
+//   - nil entries in the input slice are skipped silently (defensive: ADK
+//     can produce them when filtering tools at runtime), so the function
+//     must not panic on them
+//
+// The schema rewriting itself (lowercasing types, injecting properties) is
+// covered separately in core_test.go to avoid double-instrumenting the same
+// path.
+func TestConvertTools(t *testing.T) {
+	t.Run("propagates name, description, and rewritten schema", func(t *testing.T) {
+		m := newModelForTest()
+		tools := []*genai.Tool{{
+			FunctionDeclarations: []*genai.FunctionDeclaration{{
+				Name:        "search",
+				Description: "Search the corpus",
+				Parameters: &genai.Schema{
+					Type: genai.TypeObject,
+					Properties: map[string]*genai.Schema{
+						"q": {Type: genai.TypeString},
+					},
+					Required: []string{"q"},
+				},
+			}},
+		}}
+
+		got, err := m.convertTools(tools)
+		if err != nil {
+			t.Fatalf("error: %v", err)
+		}
+		if len(got) != 1 {
+			t.Fatalf("tools = %d, want 1", len(got))
+		}
+
+		fn := got[0].OfFunction
+		if fn == nil {
+			t.Fatalf("OfFunction = nil")
+		}
+		if fn.Function.Name != "search" {
+			t.Errorf("Name = %q, want %q", fn.Function.Name, "search")
+		}
+		if !fn.Function.Description.Valid() || fn.Function.Description.Value != "Search the corpus" {
+			t.Errorf("Description = %#v, want \"Search the corpus\"", fn.Function.Description)
+		}
+
+		params := map[string]any(fn.Function.Parameters)
+		if got, _ := params["type"].(string); got != "object" {
+			t.Errorf("schema type = %q, want \"object\" (lowercased)", got)
+		}
+		if _, ok := params["properties"].(map[string]any); !ok {
+			t.Errorf("missing properties map: %#v", params)
+		}
+	})
+
+	t.Run("nil tool entries are skipped", func(t *testing.T) {
+		m := newModelForTest()
+		got, err := m.convertTools([]*genai.Tool{nil, nil})
+		if err != nil {
+			t.Fatalf("error: %v", err)
+		}
+		if len(got) != 0 {
+			t.Errorf("tools = %d, want 0", len(got))
+		}
+	})
+
+	t.Run("multiple declarations across multiple tool groups", func(t *testing.T) {
+		m := newModelForTest()
+		tools := []*genai.Tool{
+			{FunctionDeclarations: []*genai.FunctionDeclaration{
+				{Name: "a"}, {Name: "b"},
+			}},
+			{FunctionDeclarations: []*genai.FunctionDeclaration{
+				{Name: "c"},
+			}},
+		}
+		got, err := m.convertTools(tools)
+		if err != nil {
+			t.Fatalf("error: %v", err)
+		}
+		if len(got) != 3 {
+			t.Fatalf("tools = %d, want 3", len(got))
+		}
+		names := []string{
+			got[0].OfFunction.Function.Name,
+			got[1].OfFunction.Function.Name,
+			got[2].OfFunction.Function.Name,
+		}
+		if !equalStringSlices(names, []string{"a", "b", "c"}) {
+			t.Errorf("declaration order not preserved: %v", names)
+		}
+	})
+
+	t.Run("falls back to legacy Parameters when ParametersJsonSchema is nil", func(t *testing.T) {
+		m := newModelForTest()
+		tools := []*genai.Tool{{
+			FunctionDeclarations: []*genai.FunctionDeclaration{{
+				Name: "legacy",
+				Parameters: &genai.Schema{
+					Type: genai.TypeObject,
+					Properties: map[string]*genai.Schema{
+						"x": {Type: genai.TypeNumber},
+					},
+				},
+			}},
+		}}
+		got, err := m.convertTools(tools)
+		if err != nil {
+			t.Fatalf("error: %v", err)
+		}
+		params := map[string]any(got[0].OfFunction.Function.Parameters)
+		if params["type"] != "object" {
+			t.Errorf("legacy fallback didn't produce a usable schema: %#v", params)
+		}
+	})
+}
+
+// convertInlineDataToPart emits the right SDK union variant for each MIME
+// type bucket OpenAI supports: images go through OfImageURL with a data URI,
+// audio through OfInputAudio with a format hint, and PDFs/text through
+// OfFile. Anything outside those buckets must surface an error rather than
+// silently dropping content; the caller (convertContentToMessages) lets that
+// error propagate so the request fails loudly instead of being sent without
+// the user's attachment.
+func TestConvertInlineDataToPart(t *testing.T) {
+	cases := []struct {
+		name      string
+		mime      string
+		data      []byte
+		wantKind  string
+		wantErr   bool
+		extraCheck func(t *testing.T, mime string, data []byte, p any)
+	}{
+		{
+			name:     "image/png becomes a data-URI image part",
+			mime:     "image/png",
+			data:     []byte("fakepng"),
+			wantKind: "image",
+		},
+		{
+			name:     "image/jpeg also routes to image",
+			mime:     "image/jpeg",
+			data:     []byte("fake"),
+			wantKind: "image",
+		},
+		{
+			name:     "audio/wav becomes an input audio part with format=wav",
+			mime:     "audio/wav",
+			data:     []byte("riff"),
+			wantKind: "audio_wav",
+		},
+		{
+			name:     "audio/mpeg becomes an input audio part with format=mp3",
+			mime:     "audio/mpeg",
+			data:     []byte("id3"),
+			wantKind: "audio_mp3",
+		},
+		{
+			name:     "application/pdf becomes a file part",
+			mime:     "application/pdf",
+			data:     []byte("%PDF"),
+			wantKind: "file",
+		},
+		{
+			name:     "text/plain also becomes a file part",
+			mime:     "text/plain",
+			data:     []byte("hello"),
+			wantKind: "file",
+		},
+		{
+			name:    "unsupported MIME type returns an error",
+			mime:    "video/mp4",
+			data:    []byte("x"),
+			wantErr: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := convertInlineDataToPart(&genai.Blob{MIMEType: c.mime, Data: c.data})
+			if c.wantErr {
+				if err == nil {
+					t.Errorf("expected error for MIME %q, got %#v", c.mime, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got == nil {
+				t.Fatalf("nil part returned")
+			}
+
+			switch c.wantKind {
+			case "image":
+				if got.OfImageURL == nil {
+					t.Fatalf("expected OfImageURL, got %#v", got)
+				}
+				url := got.OfImageURL.ImageURL.URL
+				if !strings.HasPrefix(url, "data:"+c.mime+";base64,") {
+					t.Errorf("URL prefix mismatch: %q", url)
+				}
+			case "audio_wav":
+				if got.OfInputAudio == nil {
+					t.Fatalf("expected OfInputAudio, got %#v", got)
+				}
+				if got.OfInputAudio.InputAudio.Format != "wav" {
+					t.Errorf("format = %q, want \"wav\"", got.OfInputAudio.InputAudio.Format)
+				}
+			case "audio_mp3":
+				if got.OfInputAudio == nil {
+					t.Fatalf("expected OfInputAudio, got %#v", got)
+				}
+				if got.OfInputAudio.InputAudio.Format != "mp3" {
+					t.Errorf("format = %q, want \"mp3\"", got.OfInputAudio.InputAudio.Format)
+				}
+			case "file":
+				if got.OfFile == nil {
+					t.Fatalf("expected OfFile, got %#v", got)
+				}
+				fd := got.OfFile.File.FileData
+				if !fd.Valid() || !strings.HasPrefix(fd.Value, "data:"+c.mime+";base64,") {
+					t.Errorf("FileData = %#v, expected data URI prefix data:%s;base64,", fd, c.mime)
+				}
+			}
+		})
+	}
+
+	t.Run("nil blob returns an error", func(t *testing.T) {
+		_, err := convertInlineDataToPart(nil)
+		if err == nil {
+			t.Errorf("expected error for nil blob")
+		}
+	})
+}

--- a/genai/openai/utils_test.go
+++ b/genai/openai/utils_test.go
@@ -1,0 +1,186 @@
+// Copyright 2025 achetronic
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package openai
+
+import (
+	"reflect"
+	"testing"
+
+	"google.golang.org/genai"
+)
+
+// schemaTypeToString is the mapping that ResponseSchema and other strongly
+// typed paths rely on. JSON Schema is case-sensitive — uppercase types are
+// invalid — so we have to assert each one explicitly. Unknown types must
+// degrade to "string" rather than empty/error to avoid sending a schema with
+// an empty "type" field, which OpenAI rejects.
+func TestSchemaTypeToString(t *testing.T) {
+	cases := []struct {
+		typ  genai.Type
+		want string
+	}{
+		{genai.TypeString, "string"},
+		{genai.TypeNumber, "number"},
+		{genai.TypeInteger, "integer"},
+		{genai.TypeBoolean, "boolean"},
+		{genai.TypeArray, "array"},
+		{genai.TypeObject, "object"},
+		{genai.TypeUnspecified, "string"},
+		{genai.Type("nonsense"), "string"},
+	}
+
+	for _, c := range cases {
+		t.Run(string(c.typ), func(t *testing.T) {
+			if got := schemaTypeToString(c.typ); got != c.want {
+				t.Errorf("schemaTypeToString(%q) = %q, want %q", c.typ, got, c.want)
+			}
+		})
+	}
+}
+
+// convertRole is intentionally minimal: it only renames "model" to
+// "assistant" and passes everything else through untouched. The OpenAI SDK
+// validates roles upstream, so this adapter shouldn't second-guess unknown
+// values — it should hand them off as-is.
+func TestConvertRole(t *testing.T) {
+	cases := []struct {
+		role string
+		want string
+	}{
+		{"user", "user"},
+		{"model", "assistant"},
+		{"system", "system"},
+		{"developer", "developer"},
+		{"function", "function"},
+		{"", ""},
+	}
+
+	for _, c := range cases {
+		t.Run(c.role, func(t *testing.T) {
+			if got := convertRole(c.role); got != c.want {
+				t.Errorf("convertRole(%q) = %q, want %q", c.role, got, c.want)
+			}
+		})
+	}
+}
+
+// convertFinishReason normalises OpenAI's stop reasons to the genai enum.
+// "stop", "tool_calls" and "function_call" all collapse into FinishReasonStop
+// because downstream agent code treats them identically (a clean turn end).
+// Unknown reasons must fall through to Unspecified so callers can detect and
+// log them rather than silently mapping to a misleading state.
+func TestConvertFinishReason(t *testing.T) {
+	cases := []struct {
+		reason string
+		want   genai.FinishReason
+	}{
+		{"stop", genai.FinishReasonStop},
+		{"length", genai.FinishReasonMaxTokens},
+		{"tool_calls", genai.FinishReasonStop},
+		{"function_call", genai.FinishReasonStop},
+		{"content_filter", genai.FinishReasonSafety},
+		{"surprise_value", genai.FinishReasonUnspecified},
+		{"", genai.FinishReasonUnspecified},
+	}
+
+	for _, c := range cases {
+		t.Run(c.reason, func(t *testing.T) {
+			if got := convertFinishReason(c.reason); got != c.want {
+				t.Errorf("convertFinishReason(%q) = %v, want %v", c.reason, got, c.want)
+			}
+		})
+	}
+}
+
+// joinTexts is just a thin wrapper but we still pin its contract: empty input
+// must produce an empty string (not "\n"), and joining preserves order with a
+// single newline between entries.
+func TestJoinTexts(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		want string
+	}{
+		{"empty", nil, ""},
+		{"one", []string{"a"}, "a"},
+		{"many", []string{"a", "b", "c"}, "a\nb\nc"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := joinTexts(c.in); got != c.want {
+				t.Errorf("joinTexts(%v) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+// parseJSONArgs must never return nil — agent code assumes the args map is
+// always safe to index. Invalid JSON, empty input, and the literal "null"
+// must all map to an empty map rather than propagate the parse error.
+func TestParseJSONArgs(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want map[string]any
+	}{
+		{"empty", "", map[string]any{}},
+		{"valid object", `{"a":1}`, map[string]any{"a": float64(1)}},
+		{"invalid json", `{`, map[string]any{}},
+		{"unrelated valid json", `[1,2,3]`, map[string]any{}},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := parseJSONArgs(c.in)
+			if !reflect.DeepEqual(got, c.want) {
+				t.Errorf("parseJSONArgs(%q) = %#v, want %#v", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+// extractText concatenates only the text parts of a Content with newlines.
+// Non-text parts must be skipped — they have no string representation we'd
+// want appearing inside an OpenAI message body.
+func TestExtractText(t *testing.T) {
+	cases := []struct {
+		name    string
+		content *genai.Content
+		want    string
+	}{
+		{"nil content", nil, ""},
+		{"no parts", &genai.Content{Parts: []*genai.Part{}}, ""},
+		{
+			name: "text parts joined with newline",
+			content: &genai.Content{Parts: []*genai.Part{
+				{Text: "hello"},
+				{Text: "world"},
+			}},
+			want: "hello\nworld",
+		},
+		{
+			name: "non-text parts skipped",
+			content: &genai.Content{Parts: []*genai.Part{
+				{Text: "before"},
+				{InlineData: &genai.Blob{MIMEType: "image/png"}},
+				{Text: "after"},
+			}},
+			want: "before\nafter",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := extractText(c.content); got != c.want {
+				t.Errorf("extractText() = %q, want %q", got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The genai SDK emits schema types in uppercase ("ARRAY", "STRING"). Anthropic rejects them ("input_schema: JSON schema is invalid") and OpenAI may follow. Both adapters only normalised the root-level type, leaving nested properties and items broken.

This change recursively lowercases every "type" field, in both adapters.

Coverage of both adapters bumped to ~70% along the way.

Fixes #15
