### PR TITLE
feat(openai): add a Responses API adapter under the openai provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,9 @@ agent, _ := llmagent.New(llmagent.Config{
 })
 ```
 
-**Which OpenAI adapter should I use?** Pick whichever fits your needs:
+### Choosing between the OpenAI adapters
+
+Pick whichever fits your needs:
 
 | Adapter | When to use |
 |---|---|

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Pick whichever fits your needs:
 | Adapter | When to use |
 |---|---|
 | `genai/openai/responses` (Responses API) | OpenAI's recommended API: native reasoning items and structured output |
-| `genai/openai` (Chat Completions) | OpenAI-compatible gateways: Ollama, vLLM, DeepSeek, Kimi, etc. |
+| `genai/openai/completions` (Chat Completions) | OpenAI-compatible gateways: Ollama, vLLM, DeepSeek, Kimi, etc. |
 
 Both OpenAI clients share the same `Config` fields (`APIKey`, `BaseURL`, `ModelName`, `HTTPOptions`). Reasoning is controlled per request through the ADK generation config: a `ThinkingConfig` maps to the Responses `reasoning.effort` level (`low` / `medium` / `high`) rather than a fixed token budget. Structured output is enabled by setting a response schema (JSON Schema) on the generation config.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Utilities and implementations for [Google's Agent Development Kit (ADK)](https:/
 
 This repository provides production-ready implementations for:
 
-- **LLM Clients**: OpenAI and Anthropic clients compatible with ADK
+- **LLM Clients**: OpenAI (Chat Completions), OpenAI Responses, and Anthropic clients compatible with ADK
 - **Session Management**: Redis-based session persistence
 - **Long-term Memory**: PostgreSQL + pgvector for semantic search
 - **Memory Tools**: Toolsets for agent-controlled memory operations
@@ -18,7 +18,8 @@ This repository provides production-ready implementations for:
 
 ```
 ├── genai/            # LLM client implementations
-│   ├── openai/       # OpenAI client (works with Ollama, OpenRouter, etc.)
+│   ├── openai/       # OpenAI Chat Completions client (works with Ollama, OpenRouter, etc.)
+│   │   └── responses/  # OpenAI Responses API client (/v1/responses)
 │   └── anthropic/    # Anthropic Claude client
 ├── session/          # Session service implementations
 │   └── redis/        # Redis session service
@@ -170,9 +171,36 @@ llmModel = genaianthropic.New(genaianthropic.Config{
 
 When streaming, the reasoning is emitted as partial content parts flagged `Thought: true`, and the thinking block (with its signature) is preserved across turns so tool-use loops keep working.
 
+### OpenAI Responses Client
+
+An adapter for the OpenAI [Responses API](https://platform.openai.com/docs/api-reference/responses) (`/v1/responses`): the interface OpenAI recommends for new applications, with native reasoning, built-in tools, and structured output. The adapter runs the API statelessly (ADK owns the conversation state and replays the full history on each call), so it integrates exactly like the Chat Completions client:
+
+```go
+import genairesponses "github.com/achetronic/adk-utils-go/genai/openai/responses"
+
+llmModel := genairesponses.New(genairesponses.Config{
+    APIKey:    os.Getenv("OPENAI_API_KEY"),
+    ModelName: "gpt-5.5",
+})
+
+agent, _ := llmagent.New(llmagent.Config{
+    Name:  "assistant",
+    Model: llmModel,
+})
+```
+
+**Which OpenAI adapter should I use?** Pick whichever fits your needs:
+
+| Adapter | When to use |
+|---|---|
+| `genai/openai/responses` (Responses API) | OpenAI's recommended API: native reasoning items and structured output |
+| `genai/openai` (Chat Completions) | OpenAI-compatible gateways: Ollama, vLLM, DeepSeek, Kimi, etc. |
+
+Both OpenAI clients share the same `Config` fields (`APIKey`, `BaseURL`, `ModelName`, `HTTPOptions`). Reasoning is controlled per request through the ADK generation config: a `ThinkingConfig` maps to the Responses `reasoning.effort` level (`low` / `medium` / `high`) rather than a fixed token budget. Structured output is enabled by setting a response schema (JSON Schema) on the generation config.
+
 ### Custom HTTP Headers
 
-Both clients support custom HTTP headers via `HTTPOptions`, useful for beta features, auth proxies, or provider-specific flags:
+All clients support custom HTTP headers via `HTTPOptions`, useful for beta features, auth proxies, or provider-specific flags:
 
 ```go
 import "net/http"
@@ -190,18 +218,20 @@ llmModel := genaianthropic.New(genaianthropic.Config{
 
 ### Supported Features
 
-Both clients support:
+All clients support:
 
 - Streaming and non-streaming responses
 - System instructions
 - Tool/function calling
 - Image inputs: inline bytes (`InlineData`, sent as base64) or remote URLs (`FileData`, passed through to the provider's image-URL field; nothing is downloaded or re-encoded)
-- Temperature, TopP, MaxOutputTokens, StopSequences
+- Temperature, TopP, MaxOutputTokens, StopSequences (the Responses API has no stop parameter, so the Responses client ignores StopSequences)
 - Extended thinking: classic budget API (`ThinkingBudgetTokens`) and adaptive effort API (`ThinkingEffort` + `ThinkingMode`)
 - Usage metadata
 - Custom HTTP headers (multi-value)
 
-Remote image URLs (`genai.Part.FileData`) work for image MIME types only; audio and documents still need uploaded bytes via `InlineData`. The URI must be `http(s)`. Plain `http` is allowed because both clients also serve API-compatible gateways (Ollama, vLLM, LiteLLM, ...) that commonly fetch from local http endpoints; which URLs a hosted provider actually fetches is decided on its side. Note that `gs://` URIs are rejected even though `genai.FileData` documents them: neither provider can read from Google Cloud Storage, so for GCS-hosted files fetch the bytes and use `InlineData`. Invalid schemes and non-image MIME types fail with a clear error instead of being silently dropped.
+Reasoning is exposed differently per provider: Anthropic uses a token budget (`ThinkingBudgetTokens`), while the OpenAI Responses client uses a reasoning effort level (`low` / `medium` / `high`). The OpenAI Responses client additionally supports structured output via JSON Schema.
+
+Remote URLs (`genai.Part.FileData`) work for image MIME types in every client; the OpenAI Responses client also accepts document URLs (PDF, Office and OpenDocument formats, text, CSV) as file inputs. Audio is not supported by the Responses API's file inputs, so audio parts are rejected with a clear error. The URI must be `http(s)`. Plain `http` is allowed because the clients also serve API-compatible gateways (Ollama, vLLM, LiteLLM, ...) that commonly fetch from local http endpoints; which URLs a hosted provider actually fetches is decided on its side. Note that `gs://` URIs are rejected even though `genai.FileData` documents them: no provider here can read from Google Cloud Storage, so for GCS-hosted files fetch the bytes and use `InlineData`. Invalid schemes and unsupported MIME types fail with a clear error instead of being silently dropped.
 
 ## Session Service (Redis)
 
@@ -491,6 +521,7 @@ Complete working examples in the `examples/` directory:
 | Example                                       | Description                                 |
 | --------------------------------------------- | ------------------------------------------- |
 | [openai-client](examples/openai-client)       | OpenAI/Ollama client usage                                |
+| [openai-responses-client](examples/openai-responses-client) | OpenAI Responses API client usage |
 | [anthropic-client](examples/anthropic-client) | Anthropic Claude client usage                             |
 | [session-memory](examples/session-memory)     | Session management with Redis                             |
 | [long-term-memory](examples/long-term-memory) | Long-term memory with PostgreSQL + pgvector               |

--- a/examples/openai-responses-client/main.go
+++ b/examples/openai-responses-client/main.go
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
+// Copyright 2025 achetronic
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// OpenAI Responses API Client Example
+//
+// This example shows how to use the OpenAI Responses API client with ADK.
+// The Responses API is OpenAI's recommended interface for new applications,
+// with native reasoning, built-in tools, and structured output. This adapter
+// runs it statelessly: ADK owns the conversation state and replays the full
+// history on each call.
+//
+// Environment variables:
+//   OPENAI_API_KEY - OpenAI API key
+//   MODEL_NAME     - Model to use (default: gpt-5.5)
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"google.golang.org/adk/v2/agent"
+	"google.golang.org/adk/v2/agent/llmagent"
+	"google.golang.org/adk/v2/runner"
+	"google.golang.org/adk/v2/session"
+	"google.golang.org/genai"
+
+	genairesponses "github.com/achetronic/adk-utils-go/genai/openai/responses"
+)
+
+func main() {
+	ctx := context.Background()
+
+	// 1. Create the Responses API client
+	llmModel := genairesponses.New(genairesponses.Config{
+		APIKey:    os.Getenv("OPENAI_API_KEY"),
+		ModelName: getEnvOrDefault("MODEL_NAME", "gpt-5.5"),
+	})
+
+	// 2. Create an agent using the Responses API model
+	myAgent, err := llmagent.New(llmagent.Config{
+		Name:        "assistant",
+		Model:       llmModel,
+		Description: "A helpful assistant",
+		Instruction: "You are a helpful assistant. Be concise.",
+	})
+	if err != nil {
+		log.Fatalf("Failed to create agent: %v", err)
+	}
+
+	// 3. Standard ADK setup: session service + runner
+	sessionService := session.InMemoryService()
+
+	sessResp, err := sessionService.Create(ctx, &session.CreateRequest{
+		AppName: "example",
+		UserID:  "user1",
+	})
+	if err != nil {
+		log.Fatalf("Failed to create session: %v", err)
+	}
+
+	runnr, err := runner.New(runner.Config{
+		AppName:        "example",
+		Agent:          myAgent,
+		SessionService: sessionService,
+	})
+	if err != nil {
+		log.Fatalf("Failed to create runner: %v", err)
+	}
+
+	// 4. Send a message and get response
+	userMsg := genai.NewContentFromText("What is the capital of France?", genai.RoleUser)
+
+	fmt.Println("User: What is the capital of France?")
+	fmt.Print("Agent: ")
+
+	for event, err := range runnr.Run(ctx, "user1", sessResp.Session.ID(), userMsg, agent.RunConfig{}) {
+		if err != nil {
+			log.Fatalf("Error: %v", err)
+		}
+		if event.Content != nil && len(event.Content.Parts) > 0 {
+			fmt.Print(event.Content.Parts[0].Text)
+		}
+	}
+	fmt.Println()
+}
+
+func getEnvOrDefault(key, defaultValue string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return defaultValue
+}

--- a/examples/openai-responses-client/main.go
+++ b/examples/openai-responses-client/main.go
@@ -1,20 +1,6 @@
 // SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
 // SPDX-License-Identifier: Apache-2.0
 
-// Copyright 2025 achetronic
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 // OpenAI Responses API Client Example
 //
 // This example shows how to use the OpenAI Responses API client with ADK.

--- a/genai/openai/responses/confirmation_filter_test.go
+++ b/genai/openai/responses/confirmation_filter_test.go
@@ -1,0 +1,133 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
+package responses
+
+import (
+	"testing"
+
+	"google.golang.org/adk/v2/tool/toolconfirmation"
+	"google.golang.org/genai"
+)
+
+// ADK's HITL confirmation protocol stores internal function calls and
+// responses (name "adk_request_confirmation") in the session. They are
+// framework bookkeeping, not tools the model declared; replaying them makes
+// the API reject the request over undeclared call/output items. The
+// conversion must drop them while keeping the real tool exchange intact.
+func TestConvertContentToInputItems_DropsADKConfirmationParts(t *testing.T) {
+	assistant := &genai.Content{
+		Role: "model",
+		Parts: []*genai.Part{
+			{FunctionCall: &genai.FunctionCall{
+				ID:   "call_real",
+				Name: "create_enrollment",
+				Args: map[string]any{"email": "a@b.c"},
+			}},
+			{FunctionCall: &genai.FunctionCall{
+				ID:   "adk_confirm_1",
+				Name: toolconfirmation.FunctionCallName,
+				Args: map[string]any{"confirmed": true},
+			}},
+		},
+	}
+
+	items, err := convertContentToInputItems(assistant, "test-origin", nil)
+	if err != nil {
+		t.Fatalf("convertContentToInputItems error: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item after filtering, got %d: %+v", len(items), items)
+	}
+	if items[0].OfFunctionCall == nil {
+		t.Fatalf("expected a function call item, got %+v", items[0])
+	}
+	if got := items[0].OfFunctionCall.Name; got != "create_enrollment" {
+		t.Errorf("remaining function call name = %q, want %q", got, "create_enrollment")
+	}
+
+	user := &genai.Content{
+		Role: "user",
+		Parts: []*genai.Part{
+			{FunctionResponse: &genai.FunctionResponse{
+				ID:       "adk_confirm_1",
+				Name:     toolconfirmation.FunctionCallName,
+				Response: map[string]any{"confirmed": true},
+			}},
+			{FunctionResponse: &genai.FunctionResponse{
+				ID:       "call_real",
+				Name:     "create_enrollment",
+				Response: map[string]any{"ok": true},
+			}},
+		},
+	}
+
+	items, err = convertContentToInputItems(user, "test-origin", nil)
+	if err != nil {
+		t.Fatalf("convertContentToInputItems error: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item after filtering, got %d: %+v", len(items), items)
+	}
+	if items[0].OfFunctionCallOutput == nil {
+		t.Fatalf("expected a function call output item, got %+v", items[0])
+	}
+	if got := items[0].OfFunctionCallOutput.CallID; got != "call_real" {
+		t.Errorf("remaining output CallID = %q, want %q", got, "call_real")
+	}
+}
+
+// A confirmation-only turn must produce no items at all, so the replayed
+// history carries no leftovers of the framework exchange.
+func TestConvertContentToInputItems_ConfirmationOnlyTurnProducesNothing(t *testing.T) {
+	content := &genai.Content{
+		Role: "model",
+		Parts: []*genai.Part{
+			{FunctionCall: &genai.FunctionCall{
+				ID:   "adk_confirm_1",
+				Name: toolconfirmation.FunctionCallName,
+				Args: map[string]any{},
+			}},
+		},
+	}
+
+	items, err := convertContentToInputItems(content, "test-origin", nil)
+	if err != nil {
+		t.Fatalf("convertContentToInputItems error: %v", err)
+	}
+	if len(items) != 0 {
+		t.Errorf("expected no items, got %d: %+v", len(items), items)
+	}
+}
+
+// A filtered confirmation call produces no item, so it cannot serve as the
+// same-turn follower a replayed reasoning item needs. The reasoning must be
+// skipped with it, or the API rejects the request over a dangling item.
+func TestConvertContentToInputItems_ConfirmationCallExcludedFromFollowers(t *testing.T) {
+	content := &genai.Content{
+		Role: "model",
+		Parts: []*genai.Part{
+			{
+				Text:    "deciding whether to ask",
+				Thought: true,
+				PartMetadata: map[string]any{
+					"reasoning_id":      "rs_1",
+					"encrypted_content": "enc-blob",
+					"reasoning_origin":  "test-origin",
+				},
+			},
+			{FunctionCall: &genai.FunctionCall{
+				ID:   "adk_confirm_1",
+				Name: toolconfirmation.FunctionCallName,
+			}},
+		},
+	}
+
+	items, err := convertContentToInputItems(content, "test-origin", nil)
+	if err != nil {
+		t.Fatalf("convertContentToInputItems error: %v", err)
+	}
+	if len(items) != 0 {
+		t.Fatalf("expected 0 items (call dropped, reasoning left without a follower), got %d: %+v", len(items), items)
+	}
+}

--- a/genai/openai/responses/core_test.go
+++ b/genai/openai/responses/core_test.go
@@ -1,0 +1,722 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
+// Copyright 2025 achetronic
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package responses
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"google.golang.org/genai"
+)
+
+func TestConvertSchema(t *testing.T) {
+	cases := []struct {
+		name   string
+		schema *genai.Schema
+		want   map[string]any
+	}{
+		{
+			name:   "nil schema yields a default empty object",
+			schema: nil,
+			want: map[string]any{
+				"type":       "object",
+				"properties": map[string]any{},
+			},
+		},
+		{
+			name: "primitive with description",
+			schema: &genai.Schema{
+				Type:        genai.TypeString,
+				Description: "a string",
+			},
+			want: map[string]any{
+				"type":        "string",
+				"description": "a string",
+			},
+		},
+		{
+			name: "object with required and nested integer property",
+			schema: &genai.Schema{
+				Type:     genai.TypeObject,
+				Required: []string{"a"},
+				Properties: map[string]*genai.Schema{
+					"a": {Type: genai.TypeInteger},
+				},
+			},
+			want: map[string]any{
+				"type":     "object",
+				"required": []string{"a"},
+				"properties": map[string]any{
+					"a": map[string]any{"type": "integer"},
+				},
+			},
+		},
+		{
+			name: "array with item schema",
+			schema: &genai.Schema{
+				Type:  genai.TypeArray,
+				Items: &genai.Schema{Type: genai.TypeString},
+			},
+			want: map[string]any{
+				"type":  "array",
+				"items": map[string]any{"type": "string"},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := convertSchema(c.schema)
+			if err != nil {
+				t.Fatalf("convertSchema() error = %v", err)
+			}
+			if !reflect.DeepEqual(got, c.want) {
+				t.Errorf("convertSchema() = %#v\nwant %#v", got, c.want)
+			}
+		})
+	}
+}
+
+func TestConvertToFunctionParams(t *testing.T) {
+	cases := []struct {
+		name string
+		in   any
+		want map[string]any
+	}{
+		{
+			name: "required auto-filled and optional fields made nullable",
+			in: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"prompt":      map[string]any{"type": "string"},
+					"heightRatio": map[string]any{"type": "integer"},
+				},
+				"required": []any{"prompt"},
+			},
+			want: map[string]any{
+				"type":                 "object",
+				"additionalProperties": false,
+				"required":             []any{"heightRatio", "prompt"},
+				"properties": map[string]any{
+					"prompt":      map[string]any{"type": "string"},
+					"heightRatio": map[string]any{"type": []any{"integer", "null"}},
+				},
+			},
+		},
+		{
+			name: "nil input returns valid empty object schema",
+			in:   nil,
+			want: map[string]any{
+				"type":                 "object",
+				"properties":           map[string]any{},
+				"required":             []any{},
+				"additionalProperties": false,
+			},
+		},
+		{
+			name: "optional nested object gets strict treatment too",
+			in: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"name": map[string]any{"type": "string"},
+					"opts": map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"color": map[string]any{"type": "string"},
+						},
+						"required": []any{"color"},
+					},
+				},
+				"required": []any{"name"},
+			},
+			want: map[string]any{
+				"type":                 "object",
+				"additionalProperties": false,
+				"required":             []any{"name", "opts"},
+				"properties": map[string]any{
+					"name": map[string]any{"type": "string"},
+					"opts": map[string]any{
+						"type":                 []any{"object", "null"},
+						"additionalProperties": false,
+						"required":             []any{"color"},
+						"properties": map[string]any{
+							"color": map[string]any{"type": "string"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "schema with properties and null required is treated as object",
+			in: map[string]any{
+				"properties": map[string]any{
+					"env": map[string]any{"type": "string"},
+				},
+				"required": nil,
+			},
+			want: map[string]any{
+				"type":                 "object",
+				"additionalProperties": false,
+				"required":             []any{"env"},
+				"properties": map[string]any{
+					"env": map[string]any{"type": []any{"string", "null"}},
+				},
+			},
+		},
+		{
+			name: "bare const and enum get their literal type filled in",
+			in: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"kind":  map[string]any{"const": "image"},
+					"level": map[string]any{"enum": []any{float64(1), float64(2)}},
+					"mixed": map[string]any{"enum": []any{"a", float64(1)}},
+				},
+				"required": []any{"kind", "level", "mixed"},
+			},
+			want: map[string]any{
+				"type":                 "object",
+				"additionalProperties": false,
+				"required":             []any{"kind", "level", "mixed"},
+				"properties": map[string]any{
+					"kind":  map[string]any{"type": "string", "const": "image"},
+					"level": map[string]any{"type": "number", "enum": []any{float64(1), float64(2)}},
+					"mixed": map[string]any{"enum": []any{"a", float64(1)}},
+				},
+			},
+		},
+		{
+			name: "$defs branches normalised and oneOf renamed to anyOf",
+			in: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"item": map[string]any{"$ref": "#/$defs/item"},
+				},
+				"required": []any{"item"},
+				"$defs": map[string]any{
+					"item": map[string]any{
+						"oneOf": []any{
+							map[string]any{
+								"type": "object",
+								"properties": map[string]any{
+									"text":    map[string]any{"type": "string"},
+									"caption": map[string]any{"type": "string"},
+									"source":  map[string]any{"$ref": "#/$defs/source"},
+								},
+								"required": []any{"text"},
+							},
+						},
+					},
+				},
+			},
+			want: map[string]any{
+				"type":                 "object",
+				"additionalProperties": false,
+				"required":             []any{"item"},
+				"properties": map[string]any{
+					"item": map[string]any{"$ref": "#/$defs/item"},
+				},
+				"$defs": map[string]any{
+					"item": map[string]any{
+						"anyOf": []any{
+							map[string]any{
+								"type":                 "object",
+								"additionalProperties": false,
+								"required":             []any{"caption", "source", "text"},
+								"properties": map[string]any{
+									"text":    map[string]any{"type": "string"},
+									"caption": map[string]any{"type": []any{"string", "null"}},
+									"source": map[string]any{
+										"anyOf": []any{
+											map[string]any{"$ref": "#/$defs/source"},
+											map[string]any{"type": "null"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			// Results are compared verbatim: the "required" order must be
+			// deterministic (sorted), because an unstable order changes the
+			// serialized tool definition on every request and breaks OpenAI
+			// prompt-cache prefix matching.
+			got := convertToStrictFunctionParams(c.in)
+			if !reflect.DeepEqual(got, c.want) {
+				t.Errorf("convertToStrictFunctionParams() = %#v\nwant %#v", got, c.want)
+			}
+		})
+	}
+}
+
+// Schemas outside the strict subset must be sent as authored with
+// strict=false instead of being normalized into a different meaning.
+func TestConvertFunctionParamsStrictFallback(t *testing.T) {
+	cases := []struct {
+		name       string
+		in         map[string]any
+		wantStrict bool
+	}{
+		{
+			name: "free-form object falls back to non-strict",
+			in: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"set": map[string]any{"type": "object", "additionalProperties": true},
+				},
+			},
+			wantStrict: false,
+		},
+		{
+			name: "array without items falls back to non-strict",
+			in: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"items": map[string]any{"type": "array"},
+				},
+			},
+			wantStrict: false,
+		},
+		{
+			name: "unsupported keyword falls back to non-strict",
+			in: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"name": map[string]any{"type": "string", "minLength": float64(1)},
+				},
+			},
+			wantStrict: false,
+		},
+		{
+			name: "expressible schema stays strict",
+			in: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"kind": map[string]any{"const": "image"},
+					"tags": map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
+				},
+				"required": []any{"kind"},
+			},
+			wantStrict: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, strict := convertFunctionParams(c.in)
+			if strict != c.wantStrict {
+				t.Fatalf("strict = %v, want %v", strict, c.wantStrict)
+			}
+			if got == nil {
+				t.Fatal("params = nil")
+			}
+			if !strict {
+				// Non-strict schemas must pass through as authored.
+				if !reflect.DeepEqual(got, c.in) {
+					t.Errorf("non-strict schema was altered:\ngot  %#v\nwant %#v", got, c.in)
+				}
+			} else {
+				if got["additionalProperties"] != false {
+					t.Errorf("strict schema missing additionalProperties=false: %#v", got)
+				}
+			}
+		})
+	}
+}
+
+// convertToStrictFunctionParams must deep-copy the input so callers who
+// reuse schemas across multiple tool registrations don't see mutations.
+func TestConvertToStrictFunctionParams_DeepCopy(t *testing.T) {
+	original := map[string]any{
+		"type":       "object",
+		"properties": map[string]any{"a": map[string]any{"type": "string"}},
+	}
+
+	_ = convertToStrictFunctionParams(original)
+
+	// The original must still have a plain string type, not ["string","null"]
+	prop := original["properties"].(map[string]any)["a"].(map[string]any)
+	if _, ok := prop["type"].(string); !ok {
+		t.Errorf("original schema was mutated: a.type = %#v, want string", prop["type"])
+	}
+	if _, has := original["additionalProperties"]; has {
+		t.Errorf("original schema was mutated: has additionalProperties")
+	}
+}
+
+// The normalised schema must serialize to identical bytes on every call:
+// tool definitions are part of the prompt-cache prefix, so any instability
+// (e.g. map-iteration order leaking into the "required" array) would cause
+// a cache miss on every request.
+func TestConvertToStrictFunctionParams_Deterministic(t *testing.T) {
+	in := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"alpha": map[string]any{"type": "string"},
+			"beta":  map[string]any{"type": "integer"},
+			"gamma": map[string]any{"type": "boolean"},
+			"delta": map[string]any{"type": "number"},
+			"omega": map[string]any{"type": "string"},
+		},
+	}
+
+	first, err := json.Marshal(convertToStrictFunctionParams(in))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	for range 50 {
+		next, err := json.Marshal(convertToStrictFunctionParams(in))
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if string(next) != string(first) {
+			t.Fatalf("serialized schema is unstable:\nfirst = %s\n next = %s", first, next)
+		}
+	}
+}
+
+func TestLowercaseTypes(t *testing.T) {
+	cases := []struct {
+		name string
+		in   map[string]any
+		want map[string]any
+	}{
+		{
+			name: "root only",
+			in:   map[string]any{"type": "OBJECT"},
+			want: map[string]any{"type": "object"},
+		},
+		{
+			name: "deeply nested",
+			in: map[string]any{
+				"type": "OBJECT",
+				"properties": map[string]any{
+					"name": map[string]any{"type": "STRING"},
+					"tags": map[string]any{
+						"type":  "ARRAY",
+						"items": map[string]any{"type": "STRING"},
+					},
+				},
+			},
+			want: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"name": map[string]any{"type": "string"},
+					"tags": map[string]any{
+						"type":  "array",
+						"items": map[string]any{"type": "string"},
+					},
+				},
+			},
+		},
+		{
+			name: "non-type fields untouched",
+			in: map[string]any{
+				"type":        "STRING",
+				"description": "DO NOT TOUCH",
+				"enum":        []any{"FOO", "BAR"},
+			},
+			want: map[string]any{
+				"type":        "string",
+				"description": "DO NOT TOUCH",
+				"enum":        []any{"FOO", "BAR"},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			lowercaseTypes(c.in)
+			if !reflect.DeepEqual(c.in, c.want) {
+				t.Errorf("after lowercaseTypes:\n got = %#v\nwant = %#v", c.in, c.want)
+			}
+		})
+	}
+}
+
+// Optional properties written as a typeless anyOf union must gain a null
+// branch when strict mode moves them into required; without it a previously
+// optional parameter silently becomes mandatory. A union that already has a
+// null branch stays unchanged.
+func TestNormalizeStrictSchema_OptionalAnyOfGetsNullBranch(t *testing.T) {
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"target": map[string]any{"anyOf": []any{
+				map[string]any{"type": "string"},
+				map[string]any{"type": "integer"},
+			}},
+		},
+	}
+
+	normalizeStrictSchema(schema)
+	normalizeStrictSchema(schema) // idempotent: a second pass adds nothing
+
+	target := schema["properties"].(map[string]any)["target"].(map[string]any)
+	branches, _ := target["anyOf"].([]any)
+	if len(branches) != 3 {
+		t.Fatalf("anyOf branches = %d, want 3 (original two plus null)", len(branches))
+	}
+	last, _ := branches[2].(map[string]any)
+	if last["type"] != "null" {
+		t.Errorf("last branch = %+v, want {type: null}", last)
+	}
+}
+
+// OpenAPI-style "nullable" is not a JSON Schema keyword and the strict
+// validator rejects it, so it must convert to a null type union (true) or
+// simply disappear (false).
+func TestNormalizeStrictSchema_NullableConvertsToNullUnion(t *testing.T) {
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"note": map[string]any{"type": "string", "nullable": true},
+			"tag":  map[string]any{"type": "string", "nullable": false},
+		},
+		"required": []any{"note", "tag"},
+	}
+
+	normalizeStrictSchema(schema)
+
+	props := schema["properties"].(map[string]any)
+	note := props["note"].(map[string]any)
+	if _, ok := note["nullable"]; ok {
+		t.Errorf("nullable key survived normalization: %+v", note)
+	}
+	if got, want := fmt.Sprintf("%v", note["type"]), "[string null]"; got != want {
+		t.Errorf("note type = %v, want %v", note["type"], want)
+	}
+	tag := props["tag"].(map[string]any)
+	if _, ok := tag["nullable"]; ok {
+		t.Errorf("nullable key survived normalization: %+v", tag)
+	}
+	if tag["type"] != "string" {
+		t.Errorf("tag type = %v, want string (nullable false adds nothing)", tag["type"])
+	}
+}
+
+// The strict validator rejects a $ref with sibling keys. The reference
+// hoists into a single-branch anyOf with the siblings kept on the node; a
+// bare $ref stays untouched; combining $ref with a union goes non-strict
+// because the conjunction cannot be expressed faithfully.
+func TestNormalizeStrictSchema_RefWithSiblings(t *testing.T) {
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"target": map[string]any{"$ref": "#/$defs/target", "description": "what to hit"},
+			"backup": map[string]any{"$ref": "#/$defs/target"},
+		},
+		"required": []any{"target", "backup"},
+		"$defs": map[string]any{
+			"target": map[string]any{"type": "string"},
+		},
+	}
+
+	normalizeStrictSchema(schema)
+
+	props := schema["properties"].(map[string]any)
+	target := props["target"].(map[string]any)
+	if _, ok := target["$ref"]; ok {
+		t.Errorf("$ref with siblings survived at top level: %+v", target)
+	}
+	if target["description"] != "what to hit" {
+		t.Errorf("description lost: %+v", target)
+	}
+	branches, _ := target["anyOf"].([]any)
+	if len(branches) != 1 || branches[0].(map[string]any)["$ref"] != "#/$defs/target" {
+		t.Errorf("anyOf = %+v, want a single $ref branch", target["anyOf"])
+	}
+	backup := props["backup"].(map[string]any)
+	if backup["$ref"] != "#/$defs/target" || len(backup) != 1 {
+		t.Errorf("bare $ref should stay untouched, got %+v", backup)
+	}
+}
+
+// An optional $ref property with siblings must end up nullable and keep its
+// annotations: the hoisted anyOf gains a null branch.
+func TestNormalizeStrictSchema_OptionalRefWithSiblings(t *testing.T) {
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"target": map[string]any{"$ref": "#/$defs/target", "description": "what to hit"},
+		},
+		"$defs": map[string]any{
+			"target": map[string]any{"type": "string"},
+		},
+	}
+
+	normalizeStrictSchema(schema)
+
+	target := schema["properties"].(map[string]any)["target"].(map[string]any)
+	if target["description"] != "what to hit" {
+		t.Errorf("description lost: %+v", target)
+	}
+	branches, _ := target["anyOf"].([]any)
+	if len(branches) != 2 {
+		t.Fatalf("anyOf = %+v, want $ref branch plus null branch", target["anyOf"])
+	}
+	if branches[0].(map[string]any)["$ref"] != "#/$defs/target" {
+		t.Errorf("first branch = %+v, want the $ref", branches[0])
+	}
+	if branches[1].(map[string]any)["type"] != "null" {
+		t.Errorf("second branch = %+v, want null", branches[1])
+	}
+}
+
+// $ref combined with a union is a conjunction the strict subset cannot
+// express, so the whole tool goes non-strict instead of being rewritten.
+func TestConvertFunctionParams_RefWithUnionGoesNonStrict(t *testing.T) {
+	params := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"target": map[string]any{
+				"$ref":  "#/$defs/a",
+				"anyOf": []any{map[string]any{"type": "string"}},
+			},
+		},
+		"$defs": map[string]any{
+			"a": map[string]any{"type": "string"},
+		},
+	}
+
+	schemaMap, strict := convertFunctionParams(params)
+	if schemaMap == nil {
+		t.Fatalf("conversion failed")
+	}
+	if strict {
+		t.Errorf("strict = true, want false for a $ref+union conjunction")
+	}
+}
+
+// Go schema generators commonly emit a root-level $ref pointing into $defs.
+// Strict mode wants a plain object root, so the reference inlines; shapes
+// that cannot inline faithfully go non-strict instead of reaching the API
+// as a root anyOf or a root $ref, which strict mode rejects.
+func TestConvertFunctionParams_RootRef(t *testing.T) {
+	t.Run("root ref with defs inlines and stays strict", func(t *testing.T) {
+		params := map[string]any{
+			"$ref": "#/$defs/args",
+			"$defs": map[string]any{
+				"args": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"query": map[string]any{"type": "string"},
+						"child": map[string]any{"$ref": "#/$defs/args"},
+					},
+					"required": []any{"query"},
+				},
+			},
+		}
+
+		schemaMap, strict := convertFunctionParams(params)
+		if !strict {
+			t.Fatalf("strict = false, want true for an inlinable root ref")
+		}
+		if _, ok := schemaMap["$ref"]; ok {
+			t.Errorf("root $ref survived: %+v", schemaMap)
+		}
+		if _, ok := schemaMap["anyOf"]; ok {
+			t.Errorf("root anyOf is rejected by strict mode: %+v", schemaMap)
+		}
+		if schemaMap["type"] != "object" {
+			t.Errorf("root type = %v, want object", schemaMap["type"])
+		}
+		if _, ok := schemaMap["$defs"].(map[string]any); !ok {
+			t.Errorf("$defs lost from the root: %+v", schemaMap)
+		}
+		props, _ := schemaMap["properties"].(map[string]any)
+		if _, ok := props["query"]; !ok {
+			t.Errorf("inlined properties missing: %+v", schemaMap)
+		}
+	})
+
+	t.Run("root ref with extra siblings goes non-strict", func(t *testing.T) {
+		params := map[string]any{
+			"$ref":        "#/$defs/args",
+			"description": "tool arguments",
+			"$defs": map[string]any{
+				"args": map[string]any{"type": "object"},
+			},
+		}
+		if _, strict := convertFunctionParams(params); strict {
+			t.Errorf("strict = true, want false for a root ref with extra siblings")
+		}
+	})
+
+	t.Run("unresolvable root ref goes non-strict", func(t *testing.T) {
+		params := map[string]any{
+			"$ref":  "#/definitions/args",
+			"$defs": map[string]any{"args": map[string]any{"type": "object"}},
+		}
+		if _, strict := convertFunctionParams(params); strict {
+			t.Errorf("strict = true, want false for an unresolvable root ref")
+		}
+	})
+
+	t.Run("non-object root goes non-strict", func(t *testing.T) {
+		params := map[string]any{
+			"type":  "array",
+			"items": map[string]any{"type": "string"},
+		}
+		if _, strict := convertFunctionParams(params); strict {
+			t.Errorf("strict = true, want false for a non-object root")
+		}
+	})
+}
+
+// The API rejects anyOf at the root of a strict schema, and a root oneOf
+// would be renamed into exactly that during normalization. Both go
+// non-strict, whether written directly or reached by inlining a root $ref.
+func TestConvertFunctionParams_RootUnionGoesNonStrict(t *testing.T) {
+	t.Run("direct root anyOf", func(t *testing.T) {
+		params := map[string]any{
+			"type": "object",
+			"anyOf": []any{
+				map[string]any{"required": []any{"a"}},
+			},
+			"properties": map[string]any{"a": map[string]any{"type": "string"}},
+		}
+		m, strict := convertFunctionParams(params)
+		if strict {
+			t.Errorf("strict = true, want false for a root anyOf")
+		}
+		if m["anyOf"] == nil {
+			t.Errorf("non-strict schema should pass through unchanged: %+v", m)
+		}
+	})
+
+	t.Run("root oneOf reached through an inlined ref", func(t *testing.T) {
+		params := map[string]any{
+			"$ref": "#/$defs/args",
+			"$defs": map[string]any{
+				"args": map[string]any{
+					"type": "object",
+					"oneOf": []any{
+						map[string]any{"properties": map[string]any{"a": map[string]any{"type": "string"}}},
+					},
+					"properties": map[string]any{"a": map[string]any{"type": "string"}},
+				},
+			},
+		}
+		if _, strict := convertFunctionParams(params); strict {
+			t.Errorf("strict = true, want false for an inlined root oneOf")
+		}
+	})
+}

--- a/genai/openai/responses/core_test.go
+++ b/genai/openai/responses/core_test.go
@@ -1,14 +1,6 @@
 // SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
 // SPDX-License-Identifier: Apache-2.0
 
-// Copyright 2025 achetronic
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-
 package responses
 
 import (

--- a/genai/openai/responses/core_test.go
+++ b/genai/openai/responses/core_test.go
@@ -712,3 +712,48 @@ func TestConvertFunctionParams_RootUnionGoesNonStrict(t *testing.T) {
 		}
 	})
 }
+
+// An optional property with an enum or a const must stay expressible as
+// absent after strict mode moves it into required: null has to satisfy the
+// value constraint too, not just the widened type, or the property becomes
+// effectively mandatory.
+func TestNormalizeStrictSchema_OptionalEnumAndConstStayNullable(t *testing.T) {
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"mode": map[string]any{"type": "string", "enum": []any{"fast", "slow"}},
+			"kind": map[string]any{"type": "string", "const": "widget"},
+		},
+	}
+
+	normalizeStrictSchema(schema)
+	normalizeStrictSchema(schema) // idempotent: a second pass adds nothing
+
+	props := schema["properties"].(map[string]any)
+
+	mode := props["mode"].(map[string]any)
+	if got, want := fmt.Sprintf("%v", mode["type"]), "[string null]"; got != want {
+		t.Errorf("mode type = %v, want %v", mode["type"], want)
+	}
+	values, _ := mode["enum"].([]any)
+	if len(values) != 3 || values[2] != nil {
+		t.Errorf("mode enum = %v, want [fast slow <nil>]", values)
+	}
+
+	kind := props["kind"].(map[string]any)
+	if _, ok := kind["const"]; ok {
+		t.Errorf("kind = %+v, want the const hoisted into anyOf", kind)
+	}
+	branches, _ := kind["anyOf"].([]any)
+	if len(branches) != 2 {
+		t.Fatalf("kind anyOf branches = %d, want 2 (const plus null): %v", len(branches), branches)
+	}
+	first, _ := branches[0].(map[string]any)
+	if first["const"] != "widget" || first["type"] != "string" {
+		t.Errorf("first branch = %v, want the original const with its type", first)
+	}
+	second, _ := branches[1].(map[string]any)
+	if second["type"] != "null" {
+		t.Errorf("second branch = %v, want {type: null}", second)
+	}
+}

--- a/genai/openai/responses/integration_test.go
+++ b/genai/openai/responses/integration_test.go
@@ -1,0 +1,142 @@
+//go:build integration
+
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
+// These tests are excluded from the default `go test ./...` run. Build them
+// with `-tags=integration`. They escalate cost on purpose:
+//
+//	Step A (free, offline): capture the request body the SDK would send and
+//	  validate it against the pinned OpenAI OpenAPI spec.
+//	Step B (paid, opt-in): only if A passed AND OPENAI_API_KEY is set, send the
+//	  request to the real API and require a non-4xx response.
+//
+// Run: go test -tags=integration ./genai/openai/responses/...
+// With a real call: OPENAI_API_KEY=sk-... go test -tags=integration ./genai/openai/responses/...
+package responses
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/getkin/kin-openapi/openapi3filter"
+	"github.com/getkin/kin-openapi/routers"
+	"github.com/getkin/kin-openapi/routers/gorillamux"
+	"google.golang.org/adk/v2/model"
+	"google.golang.org/genai"
+)
+
+// newSchemaRouter loads the pinned spec once. kin-openapi is used (not
+// libopenapi) because OpenAI's spec declares 3.1.0 yet uses the 3.0 `nullable`
+// keyword, which strict 3.1 validators refuse to compile.
+func newSchemaRouter(t *testing.T) routers.Router {
+	t.Helper()
+	loader := openapi3.NewLoader()
+	doc, err := loader.LoadFromFile("../../testdata/openapi/openai.yaml")
+	if err != nil {
+		t.Fatalf("load spec: %v", err)
+	}
+	router, err := gorillamux.NewRouter(doc)
+	if err != nil {
+		t.Fatalf("build router: %v", err)
+	}
+	return router
+}
+
+// validateBody runs step A: the captured body must satisfy the request schema.
+func validateBody(t *testing.T, router routers.Router, body []byte) {
+	t.Helper()
+	req, _ := http.NewRequest("POST", "https://api.openai.com/v1/responses", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer test")
+
+	route, pathParams, err := router.FindRoute(req)
+	if err != nil {
+		t.Fatalf("find route: %v", err)
+	}
+	err = openapi3filter.ValidateRequest(context.Background(), &openapi3filter.RequestValidationInput{
+		Request:    req,
+		PathParams: pathParams,
+		Route:      route,
+		Options:    &openapi3filter.Options{AuthenticationFunc: openapi3filter.NoopAuthenticationFunc},
+	})
+	if err != nil {
+		t.Fatalf("request body fails OpenAI schema: %v\n\nbody: %s", err, body)
+	}
+}
+
+// sendReal runs step B: dispatch the same request to the real API and require
+// a non-4xx status. Skipped unless OPENAI_API_KEY is set. A captured body is
+// passed so we assert exactly what step A validated reaches the API.
+func sendReal(t *testing.T, body []byte) {
+	t.Helper()
+	key := os.Getenv("OPENAI_API_KEY")
+	if key == "" {
+		t.Skip("OPENAI_API_KEY not set; skipping real-API step")
+	}
+	baseURL := os.Getenv("OPENAI_BASE_URL")
+	if baseURL == "" {
+		baseURL = "https://api.openai.com/v1"
+	}
+	req, _ := http.NewRequest("POST", baseURL+"/responses", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+key)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("real API call: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 && resp.StatusCode < 500 {
+		buf := new(bytes.Buffer)
+		buf.ReadFrom(resp.Body)
+		t.Fatalf("real API rejected the request: %d\n\nbody sent: %s\n\nresponse: %s", resp.StatusCode, body, buf.String())
+	}
+}
+
+// testModel returns the model name used for both steps: OPENAI_TEST_MODEL
+// when set, otherwise a real default so the paid step is not guaranteed to
+// fail on an unknown model.
+func testModel() string {
+	if m := os.Getenv("OPENAI_TEST_MODEL"); m != "" {
+		return m
+	}
+	return "gpt-5.5"
+}
+
+// captureWireBody fires one request through the SDK at a local server and
+// returns the raw bytes it put on the wire, so steps A and B validate/send the
+// exact same body the adapter produces.
+func captureWireBody(t *testing.T, req *model.LLMRequest) []byte {
+	t.Helper()
+	body := captureBodyFor(t, Config{ModelName: testModel()}, req)
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("re-marshal captured body: %v", err)
+	}
+	return raw
+}
+
+func TestIntegration_Responses_ToolCallNoArgs(t *testing.T) {
+	router := newSchemaRouter(t)
+	req := &model.LLMRequest{
+		Config: &genai.GenerateContentConfig{},
+		Contents: []*genai.Content{
+			{Role: "user", Parts: []*genai.Part{{Text: "stop"}}},
+			{Role: "model", Parts: []*genai.Part{
+				{FunctionCall: &genai.FunctionCall{ID: "call_1", Name: "exit_loop"}},
+			}},
+			{Role: "user", Parts: []*genai.Part{
+				{FunctionResponse: &genai.FunctionResponse{ID: "call_1"}},
+			}},
+		},
+	}
+	body := captureWireBody(t, req)
+	validateBody(t, router, body)
+	sendReal(t, body)
+}

--- a/genai/openai/responses/messages_test.go
+++ b/genai/openai/responses/messages_test.go
@@ -156,34 +156,68 @@ func TestConvertContentToInputItems(t *testing.T) {
 	}
 }
 
-// Model output with phase metadata must use ResponseOutputMessageParam
-// to preserve the phase field across turns. Without this, GPT-5.3-Codex+
-// models suffer performance degradation.
+// Phase must survive the replay either way, keyed on the message ID:
+// with one, the content replays as an OutputMessage carrying its full
+// identity; without one it must fall back to a plain input message (an
+// OutputMessage with an empty id is a request the API rejects), which
+// carries phase itself. Dropping phase degrades GPT-5.3-Codex+ models.
 func TestConvertContentToInputItems_PhasePreserved(t *testing.T) {
-	content := &genai.Content{
-		Role: "model",
-		Parts: []*genai.Part{
-			{
-				Text:         "thinking...",
-				PartMetadata: map[string]any{"phase": "commentary"},
+	t.Run("with message ID", func(t *testing.T) {
+		content := &genai.Content{
+			Role: "model",
+			Parts: []*genai.Part{
+				{
+					Text:         "thinking...",
+					PartMetadata: map[string]any{"phase": "commentary", "message_id": "msg_1"},
+				},
 			},
-		},
-	}
+		}
 
-	items, err := convertContentToInputItems(content, "test-origin", nil)
-	if err != nil {
-		t.Fatalf("error: %v", err)
-	}
-	if len(items) != 1 {
-		t.Fatalf("expected 1 item, got %d", len(items))
-	}
-	msg := items[0].OfOutputMessage
-	if msg == nil {
-		t.Fatalf("expected OutputMessage for phase-carrying content, got %+v", items[0])
-	}
-	if msg.Phase != "commentary" {
-		t.Errorf("Phase = %q, want commentary", msg.Phase)
-	}
+		items, err := convertContentToInputItems(content, "test-origin", nil)
+		if err != nil {
+			t.Fatalf("error: %v", err)
+		}
+		if len(items) != 1 {
+			t.Fatalf("expected 1 item, got %d", len(items))
+		}
+		msg := items[0].OfOutputMessage
+		if msg == nil {
+			t.Fatalf("expected OutputMessage for identity-carrying content, got %+v", items[0])
+		}
+		if msg.ID != "msg_1" {
+			t.Errorf("ID = %q, want msg_1", msg.ID)
+		}
+		if msg.Phase != "commentary" {
+			t.Errorf("Phase = %q, want commentary", msg.Phase)
+		}
+	})
+
+	t.Run("phase only", func(t *testing.T) {
+		content := &genai.Content{
+			Role: "model",
+			Parts: []*genai.Part{
+				{
+					Text:         "thinking...",
+					PartMetadata: map[string]any{"phase": "commentary"},
+				},
+			},
+		}
+
+		items, err := convertContentToInputItems(content, "test-origin", nil)
+		if err != nil {
+			t.Fatalf("error: %v", err)
+		}
+		if len(items) != 1 {
+			t.Fatalf("expected 1 item, got %d", len(items))
+		}
+		msg := items[0].OfMessage
+		if msg == nil {
+			t.Fatalf("expected a plain input message without an id, got %+v", items[0])
+		}
+		if msg.Phase != "commentary" {
+			t.Errorf("Phase = %q, want commentary kept on the input message", msg.Phase)
+		}
+	})
 }
 
 // Thought parts without encrypted content reference server-side IDs that only

--- a/genai/openai/responses/messages_test.go
+++ b/genai/openai/responses/messages_test.go
@@ -1,14 +1,6 @@
 // SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
 // SPDX-License-Identifier: Apache-2.0
 
-// Copyright 2025 achetronic
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-
 package responses
 
 import (

--- a/genai/openai/responses/messages_test.go
+++ b/genai/openai/responses/messages_test.go
@@ -1,0 +1,777 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
+// Copyright 2025 achetronic
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package responses
+
+import (
+	"testing"
+
+	"github.com/openai/openai-go/v3/responses"
+	"google.golang.org/genai"
+)
+
+// convertContentToInputItems bridges ADK Content into Responses API typed
+// input items. A single Content may produce multiple items: text/media
+// coalesce into a message, while FunctionCall and FunctionResponse become
+// separate typed items.
+func TestConvertContentToInputItems(t *testing.T) {
+	cases := []struct {
+		name      string
+		content   *genai.Content
+		wantCount int
+		wantTypes []string // expected item type discriminators
+		assert    func(t *testing.T, items []responses.ResponseInputItemUnionParam)
+	}{
+		{
+			name: "user text becomes a single message item",
+			content: &genai.Content{
+				Role:  "user",
+				Parts: []*genai.Part{{Text: "hello"}},
+			},
+			wantCount: 1,
+			assert: func(t *testing.T, items []responses.ResponseInputItemUnionParam) {
+				if items[0].OfMessage == nil {
+					t.Errorf("expected EasyInputMessage, got %+v", items[0])
+				}
+			},
+		},
+		{
+			name: "model text becomes an assistant message",
+			content: &genai.Content{
+				Role:  "model",
+				Parts: []*genai.Part{{Text: "hi back"}},
+			},
+			wantCount: 1,
+			assert: func(t *testing.T, items []responses.ResponseInputItemUnionParam) {
+				if items[0].OfMessage == nil {
+					t.Errorf("expected EasyInputMessage, got %+v", items[0])
+				}
+				if items[0].OfMessage.Role != responses.EasyInputMessageRoleAssistant {
+					t.Errorf("role = %q, want assistant", items[0].OfMessage.Role)
+				}
+			},
+		},
+		{
+			name: "function response becomes a function_call_output item",
+			content: &genai.Content{
+				Role: "user",
+				Parts: []*genai.Part{
+					{FunctionResponse: &genai.FunctionResponse{
+						ID:       "call_42",
+						Response: map[string]any{"ok": true},
+					}},
+				},
+			},
+			wantCount: 1,
+			assert: func(t *testing.T, items []responses.ResponseInputItemUnionParam) {
+				if items[0].OfFunctionCallOutput == nil {
+					t.Errorf("expected FunctionCallOutput, got %+v", items[0])
+				}
+			},
+		},
+		{
+			name: "model text plus function call produce two items",
+			content: &genai.Content{
+				Role: "model",
+				Parts: []*genai.Part{
+					{Text: "calling tool"},
+					{FunctionCall: &genai.FunctionCall{
+						ID:   "call_xyz",
+						Name: "do_thing",
+						Args: map[string]any{"foo": "bar"},
+					}},
+				},
+			},
+			wantCount: 2,
+			assert: func(t *testing.T, items []responses.ResponseInputItemUnionParam) {
+				if items[0].OfMessage == nil {
+					t.Errorf("first item should be a message")
+				}
+				if items[1].OfFunctionCall == nil {
+					t.Errorf("second item should be a function call")
+				}
+				if items[1].OfFunctionCall.Name != "do_thing" {
+					t.Errorf("function name = %q, want do_thing", items[1].OfFunctionCall.Name)
+				}
+			},
+		},
+		{
+			name: "user text plus inline image produces a single multi-part message",
+			content: &genai.Content{
+				Role: "user",
+				Parts: []*genai.Part{
+					{Text: "describe this"},
+					{InlineData: &genai.Blob{MIMEType: "image/png", Data: []byte("fakepng")}},
+				},
+			},
+			wantCount: 1,
+			assert: func(t *testing.T, items []responses.ResponseInputItemUnionParam) {
+				if items[0].OfMessage == nil {
+					t.Errorf("expected message item")
+				}
+			},
+		},
+		{
+			name: "function response then text produce two items",
+			content: &genai.Content{
+				Role: "model",
+				Parts: []*genai.Part{
+					{FunctionResponse: &genai.FunctionResponse{ID: "tool_1", Response: map[string]any{"result": "ok"}}},
+					{Text: "all done"},
+				},
+			},
+			wantCount: 2,
+			assert: func(t *testing.T, items []responses.ResponseInputItemUnionParam) {
+				if items[0].OfFunctionCallOutput == nil {
+					t.Errorf("first item should be function_call_output")
+				}
+				if items[1].OfMessage == nil {
+					t.Errorf("second item should be a message")
+				}
+			},
+		},
+		{
+			name: "empty parts produce no items",
+			content: &genai.Content{
+				Role:  "user",
+				Parts: []*genai.Part{{}},
+			},
+			wantCount: 0,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := convertContentToInputItems(c.content, "test-origin", nil)
+			if err != nil {
+				t.Fatalf("convertContentToInputItems error: %v", err)
+			}
+			if len(got) != c.wantCount {
+				t.Fatalf("item count = %d, want %d", len(got), c.wantCount)
+			}
+			if c.assert != nil {
+				c.assert(t, got)
+			}
+		})
+	}
+}
+
+// Model output with phase metadata must use ResponseOutputMessageParam
+// to preserve the phase field across turns. Without this, GPT-5.3-Codex+
+// models suffer performance degradation.
+func TestConvertContentToInputItems_PhasePreserved(t *testing.T) {
+	content := &genai.Content{
+		Role: "model",
+		Parts: []*genai.Part{
+			{
+				Text:         "thinking...",
+				PartMetadata: map[string]any{"phase": "commentary"},
+			},
+		},
+	}
+
+	items, err := convertContentToInputItems(content, "test-origin", nil)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+	msg := items[0].OfOutputMessage
+	if msg == nil {
+		t.Fatalf("expected OutputMessage for phase-carrying content, got %+v", items[0])
+	}
+	if msg.Phase != "commentary" {
+		t.Errorf("Phase = %q, want commentary", msg.Phase)
+	}
+}
+
+// Thought parts without encrypted content reference server-side IDs that only
+// resolve in the originating response, so they must be silently dropped to
+// avoid "Item not found" errors in stateless flows.
+func TestConvertContentToInputItems_ThoughtPartsWithoutEncryptedContentSkipped(t *testing.T) {
+	content := &genai.Content{
+		Role: "model",
+		Parts: []*genai.Part{
+			{
+				Text:         "Let me think.",
+				Thought:      true,
+				PartMetadata: map[string]any{"reasoning_id": "rs-1"},
+			},
+			{Text: "The answer."},
+		},
+	}
+
+	items, err := convertContentToInputItems(content, "test-origin", nil)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item (thought skipped), got %d", len(items))
+	}
+	if items[0].OfMessage == nil {
+		t.Fatalf("item should be message, got %+v", items[0])
+	}
+}
+
+// Thought parts carrying encrypted content must be replayed as reasoning
+// items, preceding the rest of the assistant turn: reasoning models require
+// the reasoning item that led to a function_call to be present in the input.
+func TestConvertContentToInputItems_ThoughtPartsWithEncryptedContentReplayed(t *testing.T) {
+	content := &genai.Content{
+		Role: "model",
+		Parts: []*genai.Part{
+			{
+				Text:    "Let me think.",
+				Thought: true,
+				PartMetadata: map[string]any{
+					"reasoning_id":      "rs-1",
+					"encrypted_content": "enc-blob",
+					"reasoning_origin":  "test-origin",
+				},
+			},
+			{FunctionCall: &genai.FunctionCall{ID: "call-1", Name: "get_weather"}},
+		},
+	}
+
+	items, err := convertContentToInputItems(content, "test-origin", nil)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items (reasoning + function call), got %d", len(items))
+	}
+	reasoning := items[0].OfReasoning
+	if reasoning == nil {
+		t.Fatalf("first item should be a reasoning item, got %+v", items[0])
+	}
+	if reasoning.ID != "rs-1" {
+		t.Errorf("reasoning ID = %q, want rs-1", reasoning.ID)
+	}
+	if !reasoning.EncryptedContent.Valid() || reasoning.EncryptedContent.Value != "enc-blob" {
+		t.Errorf("EncryptedContent = %+v, want enc-blob", reasoning.EncryptedContent)
+	}
+	if len(reasoning.Summary) != 1 || reasoning.Summary[0].Text != "Let me think." {
+		t.Errorf("Summary = %+v, want single summary with original text", reasoning.Summary)
+	}
+	if items[1].OfFunctionCall == nil {
+		t.Fatalf("second item should be the function call, got %+v", items[1])
+	}
+}
+
+// A reasoning item with encrypted content but no summary text (common for
+// reasoning models) must still be replayed, with an empty summary list.
+func TestConvertContentToInputItems_EncryptedThoughtWithoutSummary(t *testing.T) {
+	content := &genai.Content{
+		Role: "model",
+		Parts: []*genai.Part{
+			{
+				Thought: true,
+				PartMetadata: map[string]any{
+					"reasoning_id":      "rs-2",
+					"encrypted_content": "enc-blob-2",
+					"reasoning_origin":  "test-origin",
+				},
+			},
+			{Text: "The answer."},
+		},
+	}
+
+	items, err := convertContentToInputItems(content, "test-origin", nil)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items (reasoning + message), got %d", len(items))
+	}
+	reasoning := items[0].OfReasoning
+	if reasoning == nil {
+		t.Fatalf("first item should be a reasoning item, got %+v", items[0])
+	}
+	if len(reasoning.Summary) != 0 {
+		t.Errorf("Summary = %+v, want empty", reasoning.Summary)
+	}
+}
+
+// Encrypted reasoning content is bound to the provider/API key/model that
+// produced it; replaying it through another channel fails with a 400
+// invalid_encrypted_content. Thoughts whose recorded origin does not match
+// the requesting channel must be skipped instead of replayed.
+func TestConvertContentToInputItems_EncryptedThoughtFromOtherOriginSkipped(t *testing.T) {
+	content := &genai.Content{
+		Role: "model",
+		Parts: []*genai.Part{
+			{
+				Text:    "Let me think.",
+				Thought: true,
+				PartMetadata: map[string]any{
+					"reasoning_id":      "rs-1",
+					"encrypted_content": "enc-blob",
+					"reasoning_origin":  "azure-origin",
+				},
+			},
+			{Text: "The answer."},
+		},
+	}
+
+	items, err := convertContentToInputItems(content, "openai-origin", nil)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item (foreign thought skipped), got %d", len(items))
+	}
+	if items[0].OfMessage == nil {
+		t.Fatalf("item should be message, got %+v", items[0])
+	}
+}
+
+// Thought parts recorded before origin tracking existed have encrypted
+// content but no reasoning_origin; they must be skipped, not replayed on
+// the assumption they match.
+func TestConvertContentToInputItems_EncryptedThoughtWithoutOriginSkipped(t *testing.T) {
+	content := &genai.Content{
+		Role: "model",
+		Parts: []*genai.Part{
+			{
+				Thought: true,
+				PartMetadata: map[string]any{
+					"reasoning_id":      "rs-1",
+					"encrypted_content": "enc-blob",
+				},
+			},
+			{Text: "The answer."},
+		},
+	}
+
+	items, err := convertContentToInputItems(content, "test-origin", nil)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item (origin-less thought skipped), got %d", len(items))
+	}
+}
+
+// In multi-agent histories another agent's output (thoughts included) shows
+// up under non-assistant roles, where a reasoning item is invalid input.
+// Thought parts outside assistant turns must never be replayed.
+func TestConvertContentToInputItems_ThoughtInUserTurnSkipped(t *testing.T) {
+	content := &genai.Content{
+		Role: "user",
+		Parts: []*genai.Part{
+			{
+				Text:    "Copied agent reasoning.",
+				Thought: true,
+				PartMetadata: map[string]any{
+					"reasoning_id":      "rs-1",
+					"encrypted_content": "enc-blob",
+					"reasoning_origin":  "test-origin",
+				},
+			},
+			{Text: "User question."},
+		},
+	}
+
+	items, err := convertContentToInputItems(content, "test-origin", nil)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item (thought in user turn skipped), got %d", len(items))
+	}
+	if items[0].OfMessage == nil {
+		t.Fatalf("item should be message, got %+v", items[0])
+	}
+}
+
+// A replayed reasoning item must be followed by another item from the same
+// turn or the API rejects it as dangling. A trailing thought (e.g. from an
+// interrupted turn) must be skipped.
+func TestConvertContentToInputItems_TrailingThoughtSkipped(t *testing.T) {
+	content := &genai.Content{
+		Role: "model",
+		Parts: []*genai.Part{
+			{
+				Text:    "Thinking, then the turn was cut short.",
+				Thought: true,
+				PartMetadata: map[string]any{
+					"reasoning_id":      "rs-1",
+					"encrypted_content": "enc-blob",
+					"reasoning_origin":  "test-origin",
+				},
+			},
+		},
+	}
+
+	items, err := convertContentToInputItems(content, "test-origin", nil)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if len(items) != 0 {
+		t.Fatalf("expected 0 items (dangling thought skipped), got %d", len(items))
+	}
+}
+
+// Model output without phase should use the simpler EasyInputMessage path.
+func TestConvertContentToInputItems_NoPhaseFallback(t *testing.T) {
+	content := &genai.Content{
+		Role:  "model",
+		Parts: []*genai.Part{{Text: "plain response"}},
+	}
+
+	items, err := convertContentToInputItems(content, "test-origin", nil)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+	if items[0].OfMessage == nil {
+		t.Fatalf("expected EasyInputMessage for non-phase content, got %+v", items[0])
+	}
+}
+
+// Nil tool payloads must serialise as "{}", never "null": strict
+// OpenAI-compatible parsers (Qwen on vLLM/llama.cpp) reject "null" where
+// they expect an object.
+func TestConvertContentToInputItems_NilToolPayloadsBecomeEmptyObject(t *testing.T) {
+	content := &genai.Content{
+		Role: "model",
+		Parts: []*genai.Part{
+			{FunctionCall: &genai.FunctionCall{ID: "call_1", Name: "ping"}},
+			{FunctionResponse: &genai.FunctionResponse{ID: "call_1", Name: "ping"}},
+		},
+	}
+
+	items, err := convertContentToInputItems(content, "test-origin", nil)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(items))
+	}
+	if got := items[0].OfFunctionCall.Arguments; got != "{}" {
+		t.Errorf("Arguments = %q, want {}", got)
+	}
+	if got := items[1].OfFunctionCallOutput.Output.OfString.Value; got != "{}" {
+		t.Errorf("Output = %q, want {}", got)
+	}
+}
+
+// Parts from different output messages must be replayed as separate items
+// with their own ID and phase. Coalescing them would relabel commentary as
+// the final answer and drop the message identity models like gpt-5.3-codex
+// expect to see again.
+func TestConvertContentToInputItems_MessageBoundariesPreserved(t *testing.T) {
+	content := &genai.Content{
+		Role: "model",
+		Parts: []*genai.Part{
+			{
+				Text:         "let me check",
+				PartMetadata: map[string]any{"phase": "commentary", "message_id": "msg_1"},
+			},
+			{
+				Text:         "the answer is 4",
+				PartMetadata: map[string]any{"phase": "final_answer", "message_id": "msg_2"},
+			},
+		},
+	}
+
+	items, err := convertContentToInputItems(content, "test-origin", nil)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(items))
+	}
+	first, second := items[0].OfOutputMessage, items[1].OfOutputMessage
+	if first == nil || second == nil {
+		t.Fatalf("expected two OutputMessages, got %+v", items)
+	}
+	if first.ID != "msg_1" || second.ID != "msg_2" {
+		t.Errorf("IDs = %q, %q, want msg_1, msg_2", first.ID, second.ID)
+	}
+	if first.Phase != "commentary" || second.Phase != "final_answer" {
+		t.Errorf("phases = %q, %q, want commentary, final_answer", first.Phase, second.Phase)
+	}
+}
+
+// Parts carrying the same message_id belong to one output message and must
+// still coalesce into a single replayed item.
+func TestConvertContentToInputItems_SameMessagePartsCoalesce(t *testing.T) {
+	content := &genai.Content{
+		Role: "model",
+		Parts: []*genai.Part{
+			{
+				Text:         "first half",
+				PartMetadata: map[string]any{"phase": "final_answer", "message_id": "msg_1"},
+			},
+			{
+				Text:         "second half",
+				PartMetadata: map[string]any{"phase": "final_answer", "message_id": "msg_1"},
+			},
+		},
+	}
+
+	items, err := convertContentToInputItems(content, "test-origin", nil)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+	msg := items[0].OfOutputMessage
+	if msg == nil {
+		t.Fatalf("expected an OutputMessage, got %+v", items[0])
+	}
+	if len(msg.Content) != 2 {
+		t.Errorf("content parts = %d, want 2", len(msg.Content))
+	}
+}
+
+// A message ID without phase must still replay as an OutputMessage so the
+// item identity survives the stateless round trip.
+func TestConvertContentToInputItems_MessageIDWithoutPhase(t *testing.T) {
+	content := &genai.Content{
+		Role: "model",
+		Parts: []*genai.Part{
+			{
+				Text:         "plain but identified",
+				PartMetadata: map[string]any{"message_id": "msg_9"},
+			},
+		},
+	}
+
+	items, err := convertContentToInputItems(content, "test-origin", nil)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+	msg := items[0].OfOutputMessage
+	if msg == nil {
+		t.Fatalf("expected an OutputMessage, got %+v", items[0])
+	}
+	if msg.ID != "msg_9" {
+		t.Errorf("ID = %q, want msg_9", msg.ID)
+	}
+	if msg.Phase != "" {
+		t.Errorf("Phase = %q, want empty", msg.Phase)
+	}
+}
+
+// A refusal part must replay as a refusal content part with its message
+// status, not as completed output_text.
+func TestConvertContentToInputItems_RefusalAndStatusReplayed(t *testing.T) {
+	content := &genai.Content{
+		Role: "model",
+		Parts: []*genai.Part{
+			{
+				Text: "I cannot help with that.",
+				PartMetadata: map[string]any{
+					"message_id": "msg_1",
+					"status":     "incomplete",
+					"refusal":    true,
+				},
+			},
+		},
+	}
+
+	items, err := convertContentToInputItems(content, "test-origin", nil)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+	msg := items[0].OfOutputMessage
+	if msg == nil {
+		t.Fatalf("expected an OutputMessage, got %+v", items[0])
+	}
+	if msg.Status != "incomplete" {
+		t.Errorf("Status = %q, want incomplete", msg.Status)
+	}
+	if len(msg.Content) != 1 || msg.Content[0].OfRefusal == nil {
+		t.Fatalf("expected a refusal content part, got %+v", msg.Content)
+	}
+	if msg.Content[0].OfRefusal.Refusal != "I cannot help with that." {
+		t.Errorf("Refusal text = %q", msg.Content[0].OfRefusal.Refusal)
+	}
+}
+
+// Interleaved text and media must keep their original order: regrouping
+// them would change which image a "describe the above" refers to.
+func TestConvertContentToInputItems_InterleavedOrderPreserved(t *testing.T) {
+	content := &genai.Content{
+		Role: "user",
+		Parts: []*genai.Part{
+			{InlineData: &genai.Blob{MIMEType: "image/png", Data: []byte("a")}},
+			{Text: "describe the image above"},
+			{InlineData: &genai.Blob{MIMEType: "image/png", Data: []byte("b")}},
+			{Text: "now compare both"},
+		},
+	}
+
+	items, err := convertContentToInputItems(content, "test-origin", nil)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+	contents := items[0].OfMessage.Content.OfInputItemContentList
+	if len(contents) != 4 {
+		t.Fatalf("expected 4 content parts, got %d", len(contents))
+	}
+	wantKinds := []string{"image", "text", "image", "text"}
+	for i, want := range wantKinds {
+		isImage := contents[i].OfInputImage != nil
+		isText := contents[i].OfInputText != nil
+		if (want == "image") != isImage || (want == "text") != isText {
+			t.Errorf("content[%d]: want %s, got image=%v text=%v", i, want, isImage, isText)
+		}
+	}
+}
+
+// An identity-bearing assistant message that also holds media keeps the
+// media through the content-list path: output message content cannot carry
+// media, and dropping parts silently would change the prompt.
+func TestConvertContentToInputItems_IdentityWithMediaKeepsMedia(t *testing.T) {
+	content := &genai.Content{
+		Role: "model",
+		Parts: []*genai.Part{
+			{
+				Text:         "here is the image",
+				PartMetadata: map[string]any{"message_id": "msg_1", "phase": "final_answer"},
+			},
+			{InlineData: &genai.Blob{MIMEType: "image/png", Data: []byte("x")}},
+		},
+	}
+
+	items, err := convertContentToInputItems(content, "test-origin", nil)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+	msg := items[0].OfMessage
+	if msg == nil {
+		t.Fatalf("expected the content-list message path, got %+v", items[0])
+	}
+	contents := msg.Content.OfInputItemContentList
+	if len(contents) != 2 || contents[0].OfInputText == nil || contents[1].OfInputImage == nil {
+		t.Fatalf("expected text plus image in order, got %+v", contents)
+	}
+	if msg.Phase != "final_answer" {
+		t.Errorf("Phase = %q, want final_answer kept through the degradation", msg.Phase)
+	}
+}
+
+// The reverse order: media first, then identity-bearing text. The media-only
+// prefix has no identity yet and must adopt the incoming one instead of
+// splitting off into a separate phase-less message.
+func TestConvertContentToInputItems_MediaBeforeIdentityText(t *testing.T) {
+	content := &genai.Content{
+		Role: "model",
+		Parts: []*genai.Part{
+			{InlineData: &genai.Blob{MIMEType: "image/png", Data: []byte("x")}},
+			{
+				Text:         "the chart above says it all",
+				PartMetadata: map[string]any{"message_id": "msg_1", "phase": "final_answer"},
+			},
+		},
+	}
+
+	items, err := convertContentToInputItems(content, "test-origin", nil)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d: %+v", len(items), items)
+	}
+	msg := items[0].OfMessage
+	if msg == nil {
+		t.Fatalf("expected the content-list message path, got %+v", items[0])
+	}
+	if msg.Phase != "final_answer" {
+		t.Errorf("Phase = %q, want final_answer adopted by the whole message", msg.Phase)
+	}
+	contents := msg.Content.OfInputItemContentList
+	if len(contents) != 2 || contents[0].OfInputImage == nil || contents[1].OfInputText == nil {
+		t.Fatalf("expected image then text, got %+v", contents)
+	}
+}
+
+// Phase metadata under a user role (multi-agent histories relabel other
+// agents' output) must not reach the wire: the API rejects phase on user
+// messages.
+func TestConvertContentToInputItems_UserRoleSuppressesPhase(t *testing.T) {
+	content := &genai.Content{
+		Role: "user",
+		Parts: []*genai.Part{
+			{InlineData: &genai.Blob{MIMEType: "image/png", Data: []byte("x")}},
+			{
+				Text:         "another agent said this",
+				PartMetadata: map[string]any{"message_id": "msg_1", "phase": "final_answer"},
+			},
+		},
+	}
+
+	items, err := convertContentToInputItems(content, "test-origin", nil)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+	msg := items[0].OfMessage
+	if msg == nil {
+		t.Fatalf("expected the content-list message path, got %+v", items[0])
+	}
+	if msg.Phase != "" {
+		t.Errorf("Phase = %q, want empty on a user message", msg.Phase)
+	}
+	if msg.Role != "user" {
+		t.Errorf("Role = %q, want user", msg.Role)
+	}
+}
+
+// A dropped dangling call no longer counts as a follower: the reasoning
+// item that led to it must be skipped too, or the API rejects it as
+// dangling in turn.
+func TestConvertContentToInputItems_DanglingCallExcludedFromFollowers(t *testing.T) {
+	content := &genai.Content{
+		Role: "model",
+		Parts: []*genai.Part{
+			{
+				Text:    "planning",
+				Thought: true,
+				PartMetadata: map[string]any{
+					"reasoning_id":      "rs_1",
+					"encrypted_content": "enc-blob",
+					"reasoning_origin":  "test-origin",
+				},
+			},
+			{FunctionCall: &genai.FunctionCall{ID: "call_cancelled", Name: "slow_tool"}},
+		},
+	}
+
+	items, err := convertContentToInputItems(content, "test-origin", map[string]bool{"call_cancelled": true})
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if len(items) != 0 {
+		t.Fatalf("expected 0 items (call dropped, reasoning left without a follower), got %d: %+v", len(items), items)
+	}
+}

--- a/genai/openai/responses/response_test.go
+++ b/genai/openai/responses/response_test.go
@@ -162,6 +162,45 @@ func TestConvertResponse_ToolCall(t *testing.T) {
 	}
 }
 
+// Object-form arguments from OpenAI-compatible gateways must survive the
+// conversion; reading only the string union arm would drop them.
+func TestConvertResponse_ToolCallObjectArguments(t *testing.T) {
+	raw := []byte(`{
+		"id": "resp-2",
+		"status": "completed",
+		"output": [{
+			"type": "function_call",
+			"id": "fc-1",
+			"call_id": "call_42",
+			"name": "search",
+			"arguments": {"q": "weather"}
+		}],
+		"usage": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0,
+			"input_tokens_details": {"cached_tokens": 0},
+			"output_tokens_details": {"reasoning_tokens": 0}}
+	}`)
+
+	var resp responses.Response
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	got, err := convertResponse(&resp, "test-origin")
+	if err != nil {
+		t.Fatalf("convertResponse: %v", err)
+	}
+	if len(got.Content.Parts) != 1 {
+		t.Fatalf("expected 1 part, got %d", len(got.Content.Parts))
+	}
+	fc := got.Content.Parts[0].FunctionCall
+	if fc == nil {
+		t.Fatalf("expected FunctionCall")
+	}
+	if want := map[string]any{"q": "weather"}; !reflect.DeepEqual(fc.Args, want) {
+		t.Errorf("Args = %#v, want %#v", fc.Args, want)
+	}
+}
+
 func TestConvertResponse_TextPlusToolCall(t *testing.T) {
 	raw := []byte(`{
 		"id": "resp-3",

--- a/genai/openai/responses/response_test.go
+++ b/genai/openai/responses/response_test.go
@@ -300,6 +300,50 @@ func TestConvertResponse_WithReasoning(t *testing.T) {
 	}
 }
 
+// A reasoning item whose summary is empty but whose content field carries
+// the reasoning text (gateways converting other providers fill it that way)
+// must still produce a thought part instead of dropping the thinking.
+func TestConvertResponse_ReasoningContentFallback(t *testing.T) {
+	raw := []byte(`{
+		"id": "resp-7",
+		"status": "completed",
+		"output": [
+			{
+				"type": "reasoning",
+				"id": "rs-1",
+				"summary": [],
+				"content": [{"type": "reasoning_text", "text": "Compare the decimals."}]
+			},
+			{
+				"type": "message",
+				"id": "msg-1",
+				"role": "assistant",
+				"status": "completed",
+				"content": [{"type": "output_text", "text": "9.9 is larger."}]
+			}
+		],
+		"usage": {"input_tokens": 5, "output_tokens": 10, "total_tokens": 15,
+			"input_tokens_details": {"cached_tokens": 0},
+			"output_tokens_details": {"reasoning_tokens": 7}}
+	}`)
+
+	var resp responses.Response
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	got, err := convertResponse(&resp, "test-origin")
+	if err != nil {
+		t.Fatalf("convertResponse: %v", err)
+	}
+	if len(got.Content.Parts) != 2 {
+		t.Fatalf("expected 2 parts, got %d", len(got.Content.Parts))
+	}
+	if !got.Content.Parts[0].Thought || got.Content.Parts[0].Text != "Compare the decimals." {
+		t.Errorf("first part should carry the reasoning content text: %#v", got.Content.Parts[0])
+	}
+}
+
 // A reasoning item with encrypted content but an empty summary (common for
 // reasoning models) must still produce a thought part: dropping it would
 // lose the encrypted content needed to replay the item on the next turn.

--- a/genai/openai/responses/response_test.go
+++ b/genai/openai/responses/response_test.go
@@ -1,14 +1,6 @@
 // SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
 // SPDX-License-Identifier: Apache-2.0
 
-// Copyright 2025 achetronic
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-
 package responses
 
 import (

--- a/genai/openai/responses/response_test.go
+++ b/genai/openai/responses/response_test.go
@@ -1,0 +1,722 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
+// Copyright 2025 achetronic
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package responses
+
+import (
+	"encoding/json"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/openai/openai-go/v3/responses"
+	"github.com/openai/openai-go/v3/shared"
+	"google.golang.org/adk/v2/model"
+	"google.golang.org/genai"
+)
+
+// convertResponse rebuilds a genai.LLMResponse from the Responses API
+// Response. Tests build the response via json.Unmarshal because the SDK
+// populates internal JSON metadata through its generated UnmarshalJSON,
+// which typed union dispatch (AsAny) depends on.
+
+func TestConvertResponse_EmptyOutput(t *testing.T) {
+	resp := &responses.Response{}
+	_, err := convertResponse(resp, "test-origin")
+	if !errors.Is(err, ErrNoOutputInResponse) {
+		t.Errorf("err = %v, want %v", err, ErrNoOutputInResponse)
+	}
+}
+
+// A response whose output items are all of unknown types must fail loud
+// instead of passing as a completed turn with empty content; the error
+// names the skipped types so the operator can see what was dropped.
+func TestConvertResponse_UnknownOnlyOutput(t *testing.T) {
+	raw := []byte(`{
+		"id": "resp-u1",
+		"status": "completed",
+		"output": [
+			{"type": "web_search_call", "id": "ws-1", "status": "completed"},
+			{"type": "image_generation_call", "id": "ig-1", "status": "completed"}
+		]
+	}`)
+
+	var resp responses.Response
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	_, err := convertResponse(&resp, "test-origin")
+	if !errors.Is(err, ErrNoConsumableOutput) {
+		t.Fatalf("err = %v, want ErrNoConsumableOutput", err)
+	}
+	if !strings.Contains(err.Error(), "image_generation_call, web_search_call") {
+		t.Errorf("err = %q, want the sorted skipped item types listed", err)
+	}
+}
+
+// Unknown item types alongside consumable ones are skipped silently: the
+// forward-compatibility contract is to ignore extensions, not to fail.
+func TestConvertResponse_UnknownAlongsideKnown(t *testing.T) {
+	raw := []byte(`{
+		"id": "resp-u2",
+		"status": "completed",
+		"output": [
+			{"type": "web_search_call", "id": "ws-1", "status": "completed"},
+			{"type": "message", "id": "msg-1", "role": "assistant", "status": "completed",
+				"content": [{"type": "output_text", "text": "found it"}]}
+		]
+	}`)
+
+	var resp responses.Response
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	got, err := convertResponse(&resp, "test-origin")
+	if err != nil {
+		t.Fatalf("convertResponse: %v", err)
+	}
+	if len(got.Content.Parts) != 1 || got.Content.Parts[0].Text != "found it" {
+		t.Errorf("Content parts = %#v, want the single message text", got.Content)
+	}
+}
+
+func TestConvertResponse_TextOnly(t *testing.T) {
+	raw := []byte(`{
+		"id": "resp-1",
+		"status": "completed",
+		"output": [{
+			"type": "message",
+			"id": "msg-1",
+			"role": "assistant",
+			"status": "completed",
+			"content": [{"type": "output_text", "text": "hello world"}]
+		}],
+		"usage": {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15,
+			"input_tokens_details": {"cached_tokens": 0},
+			"output_tokens_details": {"reasoning_tokens": 0}}
+	}`)
+
+	var resp responses.Response
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	got, err := convertResponse(&resp, "test-origin")
+	if err != nil {
+		t.Fatalf("convertResponse: %v", err)
+	}
+	if !got.TurnComplete {
+		t.Errorf("TurnComplete = false, want true")
+	}
+	if got.FinishReason != genai.FinishReasonStop {
+		t.Errorf("FinishReason = %v, want Stop", got.FinishReason)
+	}
+	if len(got.Content.Parts) != 1 || got.Content.Parts[0].Text != "hello world" {
+		t.Errorf("Content parts = %#v, want single text", got.Content)
+	}
+	if got.UsageMetadata == nil || got.UsageMetadata.TotalTokenCount != 15 {
+		t.Errorf("UsageMetadata = %#v, want TotalTokenCount=15", got.UsageMetadata)
+	}
+}
+
+func TestConvertResponse_ToolCall(t *testing.T) {
+	raw := []byte(`{
+		"id": "resp-2",
+		"status": "completed",
+		"output": [{
+			"type": "function_call",
+			"id": "fc-1",
+			"call_id": "call_42",
+			"name": "search",
+			"arguments": "{\"q\":\"weather\"}"
+		}],
+		"usage": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0,
+			"input_tokens_details": {"cached_tokens": 0},
+			"output_tokens_details": {"reasoning_tokens": 0}}
+	}`)
+
+	var resp responses.Response
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	got, err := convertResponse(&resp, "test-origin")
+	if err != nil {
+		t.Fatalf("convertResponse: %v", err)
+	}
+	if len(got.Content.Parts) != 1 {
+		t.Fatalf("expected 1 part, got %d", len(got.Content.Parts))
+	}
+	fc := got.Content.Parts[0].FunctionCall
+	if fc == nil {
+		t.Fatalf("expected FunctionCall")
+	}
+	if fc.ID != "call_42" || fc.Name != "search" {
+		t.Errorf("FunctionCall = %#v, want id=call_42 name=search", fc)
+	}
+	if want := map[string]any{"q": "weather"}; !reflect.DeepEqual(fc.Args, want) {
+		t.Errorf("Args = %#v, want %#v", fc.Args, want)
+	}
+}
+
+func TestConvertResponse_TextPlusToolCall(t *testing.T) {
+	raw := []byte(`{
+		"id": "resp-3",
+		"status": "completed",
+		"output": [
+			{
+				"type": "message",
+				"id": "msg-1",
+				"role": "assistant",
+				"status": "completed",
+				"content": [{"type": "output_text", "text": "looking up"}]
+			},
+			{
+				"type": "function_call",
+				"id": "fc-1",
+				"call_id": "call_1",
+				"name": "get_weather",
+				"arguments": "{\"city\":\"Madrid\"}"
+			}
+		],
+		"usage": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0,
+			"input_tokens_details": {"cached_tokens": 0},
+			"output_tokens_details": {"reasoning_tokens": 0}}
+	}`)
+
+	var resp responses.Response
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	got, err := convertResponse(&resp, "test-origin")
+	if err != nil {
+		t.Fatalf("convertResponse: %v", err)
+	}
+	if len(got.Content.Parts) != 2 {
+		t.Fatalf("expected 2 parts, got %d", len(got.Content.Parts))
+	}
+	if got.Content.Parts[0].Text != "looking up" {
+		t.Errorf("first part text = %q", got.Content.Parts[0].Text)
+	}
+	if got.Content.Parts[1].FunctionCall == nil {
+		t.Errorf("second part should be a FunctionCall")
+	}
+}
+
+// Reasoning items (ResponseReasoningItem) appear before messages in the
+// output array. Their summary texts become Parts with Thought=true,
+// preserving the temporal order.
+func TestConvertResponse_WithReasoning(t *testing.T) {
+	raw := []byte(`{
+		"id": "resp-4",
+		"status": "completed",
+		"output": [
+			{
+				"type": "reasoning",
+				"id": "rs-1",
+				"summary": [{"type": "summary_text", "text": "Let me think about this."}]
+			},
+			{
+				"type": "message",
+				"id": "msg-1",
+				"role": "assistant",
+				"status": "completed",
+				"content": [{"type": "output_text", "text": "The answer is 42."}]
+			}
+		],
+		"usage": {"input_tokens": 5, "output_tokens": 10, "total_tokens": 15,
+			"input_tokens_details": {"cached_tokens": 0},
+			"output_tokens_details": {"reasoning_tokens": 7}}
+	}`)
+
+	var resp responses.Response
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	got, err := convertResponse(&resp, "test-origin")
+	if err != nil {
+		t.Fatalf("convertResponse: %v", err)
+	}
+	if len(got.Content.Parts) != 2 {
+		t.Fatalf("expected 2 parts, got %d", len(got.Content.Parts))
+	}
+	if !got.Content.Parts[0].Thought || got.Content.Parts[0].Text != "Let me think about this." {
+		t.Errorf("first part should be a thought: %#v", got.Content.Parts[0])
+	}
+	if got.Content.Parts[1].Thought || got.Content.Parts[1].Text != "The answer is 42." {
+		t.Errorf("second part should be plain text: %#v", got.Content.Parts[1])
+	}
+	if got.UsageMetadata == nil || got.UsageMetadata.ThoughtsTokenCount != 7 {
+		t.Errorf("ThoughtsTokenCount = %v, want 7", got.UsageMetadata)
+	}
+	// Reasoning parts must carry reasoning_id for stateless round-tripping
+	pm := got.Content.Parts[0].PartMetadata
+	if pm == nil || pm["reasoning_id"] != "rs-1" {
+		t.Errorf("PartMetadata = %v, want reasoning_id=rs-1", pm)
+	}
+}
+
+// A reasoning item with encrypted content but an empty summary (common for
+// reasoning models) must still produce a thought part: dropping it would
+// lose the encrypted content needed to replay the item on the next turn.
+func TestConvertResponse_EncryptedReasoningWithoutSummary(t *testing.T) {
+	raw := []byte(`{
+		"id": "resp-6",
+		"status": "completed",
+		"output": [
+			{
+				"type": "reasoning",
+				"id": "rs-1",
+				"summary": [],
+				"encrypted_content": "enc-blob"
+			},
+			{
+				"type": "message",
+				"id": "msg-1",
+				"role": "assistant",
+				"status": "completed",
+				"content": [{"type": "output_text", "text": "The answer is 42."}]
+			}
+		],
+		"usage": {"input_tokens": 5, "output_tokens": 10, "total_tokens": 15,
+			"input_tokens_details": {"cached_tokens": 0},
+			"output_tokens_details": {"reasoning_tokens": 7}}
+	}`)
+
+	var resp responses.Response
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	got, err := convertResponse(&resp, "test-origin")
+	if err != nil {
+		t.Fatalf("convertResponse: %v", err)
+	}
+	if len(got.Content.Parts) != 2 {
+		t.Fatalf("expected 2 parts, got %d", len(got.Content.Parts))
+	}
+	thought := got.Content.Parts[0]
+	if !thought.Thought || thought.Text != "" {
+		t.Errorf("first part should be an empty-text thought: %#v", thought)
+	}
+	pm := thought.PartMetadata
+	if pm == nil || pm["reasoning_id"] != "rs-1" || pm["encrypted_content"] != "enc-blob" {
+		t.Errorf("PartMetadata = %v, want reasoning_id=rs-1 and encrypted_content=enc-blob", pm)
+	}
+	// The origin must be recorded so replay is restricted to the channel
+	// that produced the encrypted content.
+	if pm["reasoning_origin"] != "test-origin" {
+		t.Errorf("reasoning_origin = %v, want test-origin", pm["reasoning_origin"])
+	}
+}
+
+// The origin fingerprint gates encrypted-reasoning replay to the channel
+// that produced it: it must be stable for identical configs and change when
+// any of base URL, API key, or model changes.
+func TestComputeOrigin(t *testing.T) {
+	base := computeOrigin("https://api.openai.com/v1", "sk-a", "gpt-5.5")
+
+	if computeOrigin("https://api.openai.com/v1", "sk-a", "gpt-5.5") != base {
+		t.Errorf("origin is not stable for identical inputs")
+	}
+	variants := map[string]string{
+		"base URL": computeOrigin("https://azure.example.com/v1", "sk-a", "gpt-5.5"),
+		"API key":  computeOrigin("https://api.openai.com/v1", "sk-b", "gpt-5.5"),
+		"model":    computeOrigin("https://api.openai.com/v1", "sk-a", "gpt-5.6"),
+	}
+	for dim, got := range variants {
+		if got == base {
+			t.Errorf("origin did not change when %s changed", dim)
+		}
+	}
+	// Field boundaries must be unambiguous: shifting a character across the
+	// URL/key boundary must not collide.
+	if computeOrigin("ab", "c", "m") == computeOrigin("a", "bc", "m") {
+		t.Errorf("origin collides across field boundaries")
+	}
+}
+
+// Every request must run statelessly: store=false so nothing persists
+// server-side, and encrypted reasoning requested so reasoning items can be
+// replayed across turns.
+func TestBuildResponseParams_StatelessDefaults(t *testing.T) {
+	m := New(Config{APIKey: "test", ModelName: "gpt-5.5"})
+
+	params, err := m.buildResponseParams(&model.LLMRequest{})
+	if err != nil {
+		t.Fatalf("buildResponseParams: %v", err)
+	}
+	if !params.Store.Valid() || params.Store.Value {
+		t.Errorf("Store = %+v, want false", params.Store)
+	}
+	found := false
+	for _, inc := range params.Include {
+		if inc == responses.ResponseIncludableReasoningEncryptedContent {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("Include = %v, want it to contain reasoning.encrypted_content", params.Include)
+	}
+}
+
+// Phase metadata on assistant messages must be preserved in PartMetadata
+// so that subsequent requests can echo it back to the model.
+func TestConvertResponse_PhaseMetadata(t *testing.T) {
+	raw := []byte(`{
+		"id": "resp-5",
+		"status": "completed",
+		"output": [{
+			"type": "message",
+			"id": "msg-1",
+			"role": "assistant",
+			"status": "completed",
+			"phase": "commentary",
+			"content": [{"type": "output_text", "text": "intermediate"}]
+		}],
+		"usage": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0,
+			"input_tokens_details": {"cached_tokens": 0},
+			"output_tokens_details": {"reasoning_tokens": 0}}
+	}`)
+
+	var resp responses.Response
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	got, err := convertResponse(&resp, "test-origin")
+	if err != nil {
+		t.Fatalf("convertResponse: %v", err)
+	}
+	if len(got.Content.Parts) != 1 {
+		t.Fatalf("expected 1 part, got %d", len(got.Content.Parts))
+	}
+	pm := got.Content.Parts[0].PartMetadata
+	if pm == nil {
+		t.Fatalf("PartMetadata is nil, want phase and message_id")
+	}
+	if pm["phase"] != "commentary" {
+		t.Errorf("PartMetadata[\"phase\"] = %v, want commentary", pm["phase"])
+	}
+	if pm["message_id"] != "msg-1" {
+		t.Errorf("PartMetadata[\"message_id\"] = %v, want msg-1", pm["message_id"])
+	}
+}
+
+// Messages without a phase still carry message_id in PartMetadata for
+// round-tripping, but must not have a "phase" key.
+func TestConvertResponse_NoPhase(t *testing.T) {
+	raw := []byte(`{
+		"id": "resp-6",
+		"status": "completed",
+		"output": [{
+			"type": "message",
+			"id": "msg-1",
+			"role": "assistant",
+			"status": "completed",
+			"content": [{"type": "output_text", "text": "plain"}]
+		}],
+		"usage": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0,
+			"input_tokens_details": {"cached_tokens": 0},
+			"output_tokens_details": {"reasoning_tokens": 0}}
+	}`)
+
+	var resp responses.Response
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	got, err := convertResponse(&resp, "test-origin")
+	if err != nil {
+		t.Fatalf("convertResponse: %v", err)
+	}
+	pm := got.Content.Parts[0].PartMetadata
+	if pm != nil {
+		if _, hasPhase := pm["phase"]; hasPhase {
+			t.Errorf("PartMetadata has phase key, want absent for messages without phase")
+		}
+		if pm["message_id"] != "msg-1" {
+			t.Errorf("message_id = %v, want msg-1", pm["message_id"])
+		}
+	}
+}
+
+func TestConvertUsageMetadata(t *testing.T) {
+	t.Run("populated usage maps correctly", func(t *testing.T) {
+		raw := []byte(`{
+			"input_tokens": 11, "output_tokens": 22, "total_tokens": 33,
+			"input_tokens_details": {"cached_tokens": 5},
+			"output_tokens_details": {"reasoning_tokens": 8}
+		}`)
+		var usage responses.ResponseUsage
+		if err := json.Unmarshal(raw, &usage); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		got := convertUsageMetadata(usage)
+		if got == nil {
+			t.Fatalf("got nil")
+		}
+		want := &genai.GenerateContentResponseUsageMetadata{
+			PromptTokenCount:        11,
+			CandidatesTokenCount:    22,
+			TotalTokenCount:         33,
+			ThoughtsTokenCount:      8,
+			CachedContentTokenCount: 5,
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("got = %#v, want %#v", got, want)
+		}
+	})
+
+	t.Run("zero total tokens returns nil", func(t *testing.T) {
+		usage := responses.ResponseUsage{}
+		if got := convertUsageMetadata(usage); got != nil {
+			t.Errorf("got = %#v, want nil", got)
+		}
+	})
+}
+
+// Conversion failures in the generation config must propagate out of
+// buildResponseParams instead of being swallowed, so callers see the broken
+// tool definition immediately.
+func TestBuildResponseParams_InvalidToolPropagates(t *testing.T) {
+	m := New(Config{APIKey: "test", ModelName: "gpt-5.5"})
+	req := &model.LLMRequest{
+		Config: &genai.GenerateContentConfig{
+			Tools: []*genai.Tool{{
+				FunctionDeclarations: []*genai.FunctionDeclaration{{
+					Name:                 "broken",
+					ParametersJsonSchema: make(chan int),
+				}},
+			}},
+		},
+	}
+
+	if _, err := m.buildResponseParams(req); err == nil {
+		t.Fatalf("buildResponseParams() error = nil, want tool conversion error")
+	}
+}
+
+// Reasoning summaries are only requested when the caller asks for thoughts;
+// the effort level maps regardless.
+func TestBuildResponseParams_ReasoningSummaryFollowsIncludeThoughts(t *testing.T) {
+	m := New(Config{APIKey: "test", ModelName: "gpt-5.5"})
+
+	req := &model.LLMRequest{Config: &genai.GenerateContentConfig{
+		ThinkingConfig: &genai.ThinkingConfig{
+			IncludeThoughts: true,
+			ThinkingLevel:   genai.ThinkingLevelLow,
+		},
+	}}
+	params, err := m.buildResponseParams(req)
+	if err != nil {
+		t.Fatalf("buildResponseParams: %v", err)
+	}
+	if params.Reasoning.Summary != shared.ReasoningSummaryAuto {
+		t.Errorf("Summary = %q, want auto", params.Reasoning.Summary)
+	}
+	if params.Reasoning.Effort != shared.ReasoningEffortLow {
+		t.Errorf("Effort = %q, want low", params.Reasoning.Effort)
+	}
+
+	req.Config.ThinkingConfig.IncludeThoughts = false
+	params, err = m.buildResponseParams(req)
+	if err != nil {
+		t.Fatalf("buildResponseParams: %v", err)
+	}
+	if params.Reasoning.Summary != "" {
+		t.Errorf("Summary = %q, want unset when thoughts are not requested", params.Reasoning.Summary)
+	}
+	if params.Reasoning.Effort != shared.ReasoningEffortLow {
+		t.Errorf("Effort = %q, want low", params.Reasoning.Effort)
+	}
+}
+
+// Malformed function-call arguments must fail the conversion: a tool with
+// side effects must not run with silently emptied arguments.
+func TestConvertResponse_MalformedArgumentsError(t *testing.T) {
+	raw := []byte(`{
+		"id": "resp-7",
+		"status": "completed",
+		"output": [{
+			"type": "function_call",
+			"id": "fc-1",
+			"call_id": "call_1",
+			"name": "delete_things",
+			"arguments": "{"
+		}],
+		"usage": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0,
+			"input_tokens_details": {"cached_tokens": 0},
+			"output_tokens_details": {"reasoning_tokens": 0}}
+	}`)
+
+	var resp responses.Response
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if _, err := convertResponse(&resp, "test-origin"); err == nil {
+		t.Fatalf("expected an error for malformed arguments, got none")
+	}
+}
+
+// A raw JSON schema set via ResponseJsonSchema must reach the request as a
+// json_schema response format: strict when it fits the subset, non-strict
+// with the schema intact otherwise. Ignoring it silently would let the model
+// answer unconstrained while the caller believes a schema is enforced.
+func TestBuildResponseParams_ResponseJsonSchema(t *testing.T) {
+	m := New(Config{APIKey: "test", ModelName: "gpt-5.5"})
+
+	strictSchema := map[string]any{
+		"type":       "object",
+		"properties": map[string]any{"score": map[string]any{"type": "number"}},
+	}
+	params, err := m.buildResponseParams(&model.LLMRequest{Config: &genai.GenerateContentConfig{
+		ResponseJsonSchema: strictSchema,
+	}})
+	if err != nil {
+		t.Fatalf("buildResponseParams: %v", err)
+	}
+	format := params.Text.Format.OfJSONSchema
+	if format == nil {
+		t.Fatalf("expected a json_schema response format, got %+v", params.Text.Format)
+	}
+	if !format.Strict.Valid() || !format.Strict.Value {
+		t.Errorf("Strict = %+v, want true for a subset-compatible schema", format.Strict)
+	}
+
+	lossySchema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"code": map[string]any{"type": "string", "minLength": 2},
+		},
+	}
+	params, err = m.buildResponseParams(&model.LLMRequest{Config: &genai.GenerateContentConfig{
+		ResponseJsonSchema: lossySchema,
+	}})
+	if err != nil {
+		t.Fatalf("buildResponseParams: %v", err)
+	}
+	format = params.Text.Format.OfJSONSchema
+	if format == nil {
+		t.Fatalf("expected a json_schema response format, got %+v", params.Text.Format)
+	}
+	if !format.Strict.Valid() || format.Strict.Value {
+		t.Errorf("Strict = %+v, want false when the subset cannot express the schema", format.Strict)
+	}
+	code := format.Schema["properties"].(map[string]any)["code"].(map[string]any)
+	if code["minLength"] != float64(2) && code["minLength"] != 2 {
+		t.Errorf("minLength = %v, want preserved verbatim", code["minLength"])
+	}
+}
+
+// Refusal content must keep its identity in PartMetadata: replaying it as
+// plain output_text would lose the refusal semantics, and message status
+// must survive so incomplete messages do not come back as completed.
+func TestConvertResponse_RefusalAndStatusMetadata(t *testing.T) {
+	raw := []byte(`{
+		"id": "resp-8",
+		"status": "completed",
+		"output": [{
+			"type": "message",
+			"id": "msg-1",
+			"role": "assistant",
+			"status": "incomplete",
+			"content": [{"type": "refusal", "refusal": "I cannot help with that."}]
+		}],
+		"usage": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0,
+			"input_tokens_details": {"cached_tokens": 0},
+			"output_tokens_details": {"reasoning_tokens": 0}}
+	}`)
+
+	var resp responses.Response
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	got, err := convertResponse(&resp, "test-origin")
+	if err != nil {
+		t.Fatalf("convertResponse: %v", err)
+	}
+	if len(got.Content.Parts) != 1 {
+		t.Fatalf("expected 1 part, got %d", len(got.Content.Parts))
+	}
+	pm := got.Content.Parts[0].PartMetadata
+	if pm == nil || pm["refusal"] != true || pm["status"] != "incomplete" || pm["message_id"] != "msg-1" {
+		t.Errorf("PartMetadata = %v, want refusal=true status=incomplete message_id=msg-1", pm)
+	}
+}
+
+// A failed response must surface the server's error instead of degrading
+// into "no output items" or, worse, passing partial output as a completed
+// turn.
+func TestConvertResponse_FailedStatus(t *testing.T) {
+	raw := []byte(`{
+		"id": "resp-9",
+		"status": "failed",
+		"error": {"code": "server_error", "message": "the backend fell over"},
+		"output": [{
+			"type": "message",
+			"id": "msg-1",
+			"role": "assistant",
+			"status": "incomplete",
+			"content": [{"type": "output_text", "text": "partial"}]
+		}],
+		"usage": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0,
+			"input_tokens_details": {"cached_tokens": 0},
+			"output_tokens_details": {"reasoning_tokens": 0}}
+	}`)
+
+	var resp responses.Response
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	_, err := convertResponse(&resp, "test-origin")
+	if err == nil {
+		t.Fatalf("expected an error for a failed response, got none")
+	}
+	if got := err.Error(); got != "openai responses api: the backend fell over" {
+		t.Errorf("err = %q, want the server message", got)
+	}
+}
+
+// A typed ResponseSchema with a non-object root must go non-strict: strict
+// mode requires an object root, and the typed schema allows primitives and
+// arrays.
+func TestBuildResponseParams_TypedSchemaNonObjectRoot(t *testing.T) {
+	m := New(Config{APIKey: "test", ModelName: "gpt-5.5"})
+
+	params, err := m.buildResponseParams(&model.LLMRequest{Config: &genai.GenerateContentConfig{
+		ResponseSchema: &genai.Schema{
+			Type:  genai.TypeArray,
+			Items: &genai.Schema{Type: genai.TypeString},
+		},
+	}})
+	if err != nil {
+		t.Fatalf("buildResponseParams: %v", err)
+	}
+	format := params.Text.Format.OfJSONSchema
+	if format == nil {
+		t.Fatalf("expected a json_schema response format, got %+v", params.Text.Format)
+	}
+	if !format.Strict.Valid() || format.Strict.Value {
+		t.Errorf("Strict = %+v, want false for a non-object root", format.Strict)
+	}
+	if format.Schema["type"] != "array" {
+		t.Errorf("schema root = %v, want the array kept verbatim", format.Schema["type"])
+	}
+}

--- a/genai/openai/responses/responses.go
+++ b/genai/openai/responses/responses.go
@@ -816,10 +816,12 @@ func convertContentToInputItems(content *genai.Content, origin string, dangling 
 		if part.Thought {
 			continue
 		}
-		if part.FunctionCall != nil && dangling[part.FunctionCall.ID] {
+		if part.FunctionCall != nil &&
+			(dangling[part.FunctionCall.ID] || common.IsADKInternalCall(part.FunctionCall.Name)) {
 			continue
 		}
-		if part.FunctionResponse != nil && dangling[part.FunctionResponse.ID] {
+		if part.FunctionResponse != nil &&
+			(dangling[part.FunctionResponse.ID] || common.IsADKInternalCall(part.FunctionResponse.Name)) {
 			continue
 		}
 		if part.FunctionCall != nil || part.FunctionResponse != nil ||
@@ -924,6 +926,12 @@ func convertContentToInputItems(content *genai.Content, origin string, dangling 
 	for i, part := range content.Parts {
 		switch {
 		case part.FunctionResponse != nil:
+			// Skip ADK internal framework parts (HITL confirmation
+			// protocol): they are not tools the model declared, and the
+			// API rejects undeclared call/output items.
+			if common.IsADKInternalCall(part.FunctionResponse.Name) {
+				continue
+			}
 			if dangling[part.FunctionResponse.ID] {
 				continue
 			}
@@ -937,6 +945,9 @@ func convertContentToInputItems(content *genai.Content, origin string, dangling 
 			))
 
 		case part.FunctionCall != nil:
+			if common.IsADKInternalCall(part.FunctionCall.Name) {
+				continue
+			}
 			if dangling[part.FunctionCall.ID] {
 				continue
 			}

--- a/genai/openai/responses/responses.go
+++ b/genai/openai/responses/responses.go
@@ -1,0 +1,2122 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
+// Copyright 2025 achetronic
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package responses provides an OpenAI Responses API (/v1/responses)
+// implementation for the ADK.
+//
+// The Responses API is the interface OpenAI recommends for new applications,
+// with native reasoning, built-in tools, and structured output.
+//
+// This adapter drives the API statelessly to match ADK's model: ADK owns the
+// conversation state and passes the full history on every call, so each request
+// replays that history as input items instead of chaining server-side state via
+// previous_response_id. Requests are sent with store=false so nothing is
+// persisted server-side, and reasoning is requested with encrypted_content so
+// reasoning items can be replayed across turns: this keeps the model's chain
+// of thought available between tool calls, as reasoning models require.
+// Reasoning items without encrypted content (e.g. from gateways that do not
+// support the include parameter) are skipped on replay, since their bare IDs
+// only resolve in the context of the originating response.
+//
+// Encrypted reasoning content is bound to the credentials that produced it:
+// the API encrypts it with the organization's key, and replaying it through a
+// different provider, API key, or model fails with a 400
+// invalid_encrypted_content error. Sessions may switch channels mid-flight
+// (e.g. OpenAI to Azure fallback), so each reasoning part records the origin
+// (a fingerprint of base URL, API key, and model) and is replayed only when
+// it matches the requesting model; otherwise the encrypted content is
+// dropped and the turn degrades gracefully to fresh reasoning.
+//
+// For OpenAI-compatible gateways (Ollama, vLLM, DeepSeek, Kimi, etc.) that only
+// expose the Chat Completions endpoint, use the parent openai package instead.
+package responses
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"iter"
+	"maps"
+	"mime"
+	"net/http"
+	"os"
+	"path"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/achetronic/adk-utils-go/genai/common"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+	"github.com/openai/openai-go/v3/packages/param"
+	"github.com/openai/openai-go/v3/responses"
+	"github.com/openai/openai-go/v3/shared"
+	"google.golang.org/adk/v2/model"
+	"google.golang.org/genai"
+)
+
+var _ model.LLM = &Model{}
+
+var (
+	ErrNoOutputInResponse = errors.New("no output items in OpenAI Responses API response")
+	// ErrNoConsumableOutput reports a response whose output items were all
+	// skipped (unknown item types, or known items carrying no content), so
+	// converting it would produce an empty completed turn.
+	ErrNoConsumableOutput = errors.New("no consumable output items in OpenAI Responses API response")
+)
+
+// Model implements model.LLM using the OpenAI Responses API.
+type Model struct {
+	client    *openai.Client
+	modelName string
+	// origin fingerprints the channel (base URL, API key, model) this Model
+	// talks to. Encrypted reasoning content is only replayed to the channel
+	// that produced it; see the package documentation.
+	origin string
+}
+
+// HTTPOptions holds optional HTTP-level configuration for the OpenAI client.
+type HTTPOptions struct {
+	Client  *http.Client
+	Headers http.Header
+}
+
+// Config holds the configuration for creating a Responses API Model.
+type Config struct {
+	// APIKey for authentication. Falls back to OPENAI_API_KEY env var if empty.
+	APIKey string
+	// BaseURL for the API endpoint.
+	BaseURL string
+	// ModelName specifies which model to use (e.g., "gpt-4o", "gpt-5.4").
+	ModelName string
+	// HTTPOptions holds optional HTTP-level overrides (e.g. extra headers).
+	HTTPOptions HTTPOptions
+}
+
+// New creates a new Responses API Model with the given configuration.
+func New(cfg Config) *Model {
+	var opts []option.RequestOption
+
+	if cfg.APIKey != "" {
+		opts = append(opts, option.WithAPIKey(cfg.APIKey))
+	}
+	if cfg.BaseURL != "" {
+		opts = append(opts, option.WithBaseURL(cfg.BaseURL))
+	}
+	if cfg.HTTPOptions.Client != nil {
+		opts = append(opts, option.WithHTTPClient(cfg.HTTPOptions.Client))
+	}
+	for k, vals := range cfg.HTTPOptions.Headers {
+		for _, v := range vals {
+			opts = append(opts, option.WithHeaderAdd(k, v))
+		}
+	}
+
+	client := openai.NewClient(opts...)
+
+	apiKey := cfg.APIKey
+	if apiKey == "" {
+		apiKey = os.Getenv("OPENAI_API_KEY")
+	}
+
+	return &Model{
+		client:    &client,
+		modelName: cfg.ModelName,
+		origin:    computeOrigin(cfg.BaseURL, apiKey, cfg.ModelName),
+	}
+}
+
+// computeOrigin fingerprints a channel so encrypted reasoning content is only
+// replayed to the channel that produced it. The API encrypts reasoning with
+// the organization's key, so any change of provider, API key, or model makes
+// previously captured content undecryptable (400 invalid_encrypted_content).
+// The fingerprint deliberately covers all three dimensions.
+func computeOrigin(baseURL, apiKey, modelName string) string {
+	h := sha256.New()
+	for _, s := range []string{baseURL, apiKey, modelName} {
+		h.Write([]byte(s))
+		h.Write([]byte{0})
+	}
+	return hex.EncodeToString(h.Sum(nil))[:16]
+}
+
+// Name returns the model name.
+func (m *Model) Name() string {
+	return m.modelName
+}
+
+// GenerateContent sends a request to the LLM and returns responses.
+// Set stream=true for streaming responses, false for a single response.
+func (m *Model) GenerateContent(ctx context.Context, req *model.LLMRequest, stream bool) iter.Seq2[*model.LLMResponse, error] {
+	if stream {
+		return m.generateStream(ctx, req)
+	}
+	return m.generate(ctx, req)
+}
+
+// generate sends a non-streaming request and yields a single response.
+func (m *Model) generate(ctx context.Context, req *model.LLMRequest) iter.Seq2[*model.LLMResponse, error] {
+	return func(yield func(*model.LLMResponse, error) bool) {
+		params, err := m.buildResponseParams(req)
+		if err != nil {
+			yield(nil, err)
+			return
+		}
+
+		resp, err := m.client.Responses.New(ctx, params)
+		if err != nil {
+			yield(nil, err)
+			return
+		}
+
+		llmResp, err := convertResponse(resp, m.origin)
+		if err != nil {
+			yield(nil, err)
+			return
+		}
+
+		yield(llmResp, nil)
+	}
+}
+
+// generateStream sends a streaming request and yields partial responses
+// as they arrive, followed by a final aggregated response.
+//
+// Streamed deltas (Partial=true) are display-only; ADK persists only the final
+// non-partial event. The stream must therefore always end with a complete
+// aggregated event. Some OpenAI-compatible gateways omit the aggregated output
+// from response.completed, or close the connection without any terminal event
+// at all. Relying solely on the server-provided output then yields an empty
+// final event, so the assistant turn is lost from history on reload even though
+// it streamed fine. As a fallback the deltas are accumulated locally,
+// mirroring the Chat Completions adapter.
+func (m *Model) generateStream(ctx context.Context, req *model.LLMRequest) iter.Seq2[*model.LLMResponse, error] {
+	return func(yield func(*model.LLMResponse, error) bool) {
+		params, err := m.buildResponseParams(req)
+		if err != nil {
+			yield(nil, err)
+			return
+		}
+
+		stream := m.client.Responses.NewStreaming(ctx, params)
+		// The iterator returns early on terminal events, so the body is
+		// closed explicitly; leaving it open leaks the connection.
+		defer stream.Close()
+
+		var acc streamAccumulator
+		for stream.Next() {
+			event := stream.Current()
+
+			switch event.Type {
+			case "response.output_text.delta":
+				if event.Delta == "" {
+					continue
+				}
+				acc.addText(event.ItemID, event.OutputIndex, event.Delta)
+				llmResp := &model.LLMResponse{
+					Content: &genai.Content{
+						Role:  genai.RoleModel,
+						Parts: []*genai.Part{{Text: event.Delta}},
+					},
+					Partial:      true,
+					TurnComplete: false,
+				}
+				if !yield(llmResp, nil) {
+					return
+				}
+
+			case "response.refusal.delta":
+				if event.Delta == "" {
+					continue
+				}
+				acc.addRefusal(event.ItemID, event.OutputIndex, event.Delta)
+				llmResp := &model.LLMResponse{
+					Content: &genai.Content{
+						Role:  genai.RoleModel,
+						Parts: []*genai.Part{{Text: event.Delta}},
+					},
+					Partial:      true,
+					TurnComplete: false,
+				}
+				if !yield(llmResp, nil) {
+					return
+				}
+
+			case "response.reasoning_summary_text.delta":
+				if event.Delta == "" {
+					continue
+				}
+				acc.reasoning.WriteString(event.Delta)
+				llmResp := &model.LLMResponse{
+					Content: &genai.Content{
+						Role:  genai.RoleModel,
+						Parts: []*genai.Part{{Text: event.Delta, Thought: true}},
+					},
+					Partial:      true,
+					TurnComplete: false,
+				}
+				if !yield(llmResp, nil) {
+					return
+				}
+
+			case "response.output_item.done":
+				// Completed function calls are accumulated so the fallback
+				// final event includes them: losing a tool call would
+				// silently break the agent loop.
+				if event.Item.Type == "function_call" {
+					args, err := parseJSONArgs(event.Item.Arguments.OfString)
+					if err != nil {
+						yield(nil, err)
+						return
+					}
+					acc.functionCalls = append(acc.functionCalls, &genai.FunctionCall{
+						ID:   event.Item.CallID,
+						Name: event.Item.Name,
+						Args: args,
+					})
+				}
+				// Complete items are kept as well: when the terminal event
+				// lacks aggregated output they rebuild the turn with message
+				// IDs, phase, and encrypted reasoning intact, which the bare
+				// delta fallback cannot.
+				switch event.Item.Type {
+				case "message", "reasoning", "function_call":
+					acc.items = append(acc.items, doneItem{
+						index: event.OutputIndex,
+						item:  event.Item,
+					})
+				}
+
+			case "response.completed", "response.incomplete":
+				resp := &event.Response
+				llmResp, err := convertResponse(resp, m.origin)
+				if err != nil && !errors.Is(err, ErrNoOutputInResponse) && !errors.Is(err, ErrNoConsumableOutput) {
+					// A malformed terminal payload (e.g. broken function
+					// arguments) is a real error, not a missing-output case;
+					// degrading to the delta fallback would swallow it.
+					yield(nil, err)
+					return
+				}
+				if err != nil || hasNoContent(llmResp) {
+					// The terminal event carried no aggregated output: rebuild the
+					// final response from what the stream delivered, otherwise ADK
+					// would persist an empty event and the turn would be lost.
+					llmResp = acc.fallbackResponse(resp, m.origin)
+					if hasNoContent(llmResp) {
+						// Nothing streamed either: surface why the turn is
+						// empty instead of yielding it as completed.
+						if err == nil {
+							err = ErrNoConsumableOutput
+						}
+						yield(nil, err)
+						return
+					}
+				}
+				yield(llmResp, nil)
+				return
+
+			case "response.failed":
+				errMsg := event.Response.Error.Message
+				if errMsg == "" {
+					errMsg = "response generation failed"
+				}
+				yield(nil, fmt.Errorf("openai responses api: %s", errMsg))
+				return
+
+			case "error":
+				yield(nil, fmt.Errorf("openai responses api stream error: %s", event.Message))
+				return
+			}
+		}
+
+		if err := stream.Err(); err != nil {
+			yield(nil, err)
+			return
+		}
+
+		// The stream ended without any terminal event (some gateways just close
+		// the connection after the last delta). Synthesize the final event from
+		// what was accumulated so the turn is persisted and ADK does not raise
+		// "last event is not final".
+		if acc.hasContent() || len(acc.items) > 0 {
+			shadow := responses.Response{Status: responses.ResponseStatusCompleted}
+			yield(acc.fallbackResponse(&shadow, m.origin), nil)
+		}
+	}
+}
+
+// streamAccumulator collects streamed deltas so a complete final response
+// can be rebuilt when the terminal event lacks the aggregated output.
+// reasoning holds the reasoning summary; texts and refusals hold delta text
+// per output item, so the fallback can tell which items the done events
+// covered; functionCalls holds tool calls completed during the stream;
+// items holds the complete output items from output_item.done events.
+type streamAccumulator struct {
+	reasoning     strings.Builder
+	texts         []*deltaBucket
+	refusals      []*deltaBucket
+	functionCalls []*genai.FunctionCall
+	items         []doneItem
+}
+
+// deltaBucket accumulates streamed delta text for one output item; index is
+// the item's output_index, so uncovered buckets merge back in stream order.
+type deltaBucket struct {
+	itemID string
+	index  int64
+	text   strings.Builder
+}
+
+// doneItem pairs a complete output item with its output_index so the
+// fallback rebuilds the output array in order regardless of event arrival.
+type doneItem struct {
+	index int64
+	item  responses.ResponseOutputItemUnion
+}
+
+func appendDelta(buckets []*deltaBucket, itemID string, index int64, delta string) []*deltaBucket {
+	for _, b := range buckets {
+		if b.itemID == itemID {
+			b.text.WriteString(delta)
+			return buckets
+		}
+	}
+	b := &deltaBucket{itemID: itemID, index: index}
+	b.text.WriteString(delta)
+	return append(buckets, b)
+}
+
+func (a *streamAccumulator) addText(itemID string, index int64, delta string) {
+	a.texts = appendDelta(a.texts, itemID, index, delta)
+}
+
+func (a *streamAccumulator) addRefusal(itemID string, index int64, delta string) {
+	a.refusals = appendDelta(a.refusals, itemID, index, delta)
+}
+
+// joinDeltas concatenates bucket text in arrival order.
+func joinDeltas(buckets []*deltaBucket) string {
+	var sb strings.Builder
+	for _, b := range buckets {
+		sb.WriteString(b.text.String())
+	}
+	return sb.String()
+}
+
+// fallbackResponse rebuilds the final turn when the terminal event lacked
+// aggregated output. Complete done items are preferred: they keep message
+// IDs, phase, status, and encrypted reasoning for the next stateless
+// replay. Deltas the done items did not cover are merged in, and bare
+// deltas alone are the last resort.
+func (a *streamAccumulator) fallbackResponse(resp *responses.Response, origin string) *model.LLMResponse {
+	if len(a.items) > 0 {
+		merged := append(append([]doneItem{}, a.items...), a.uncoveredBuckets()...)
+		sort.SliceStable(merged, func(i, j int) bool {
+			return merged[i].index < merged[j].index
+		})
+		output := make([]responses.ResponseOutputItemUnion, len(merged))
+		for i, di := range merged {
+			output[i] = di.item
+		}
+		shadow := *resp
+		shadow.Output = output
+		if r, err := convertResponse(&shadow, origin); err == nil && !hasNoContent(r) {
+			a.fillMissingReasoning(r)
+			return r
+		}
+	}
+	return a.finalResponse(
+		convertStatus(resp.Status, resp.IncompleteDetails),
+		convertUsageMetadata(resp.Usage),
+	)
+}
+
+// uncoveredBuckets turns delta buckets whose item never produced a done
+// event into synthetic message items: a gateway may complete only some
+// items while others streamed as bare deltas, and dropping either side
+// would lose output the consumer already saw. Sorting the result with the
+// done items by output_index restores the stream order. Buckets without an
+// item ID (a gateway that omits item_id) fall back to a coarse check
+// against any text the done message items carry.
+func (a *streamAccumulator) uncoveredBuckets() []doneItem {
+	doneMessageIDs := map[string]bool{}
+	doneHasText := false
+	for _, di := range a.items {
+		if di.item.Type != "message" {
+			continue
+		}
+		if di.item.ID != "" {
+			doneMessageIDs[di.item.ID] = true
+		}
+		for _, cp := range di.item.Content {
+			if cp.Text != "" || cp.Refusal != "" {
+				doneHasText = true
+			}
+		}
+	}
+	covered := func(b *deltaBucket) bool {
+		if b.itemID == "" {
+			return doneHasText
+		}
+		return doneMessageIDs[b.itemID]
+	}
+
+	var synthetic []doneItem
+	for _, b := range a.texts {
+		if !covered(b) {
+			synthetic = append(synthetic, doneItem{index: b.index, item: responses.ResponseOutputItemUnion{
+				Type:    "message",
+				ID:      b.itemID,
+				Role:    "assistant",
+				Status:  "completed",
+				Content: []responses.ResponseOutputMessageContentUnion{{Type: "output_text", Text: b.text.String()}},
+			}})
+		}
+	}
+	for _, b := range a.refusals {
+		if !covered(b) {
+			synthetic = append(synthetic, doneItem{index: b.index, item: responses.ResponseOutputItemUnion{
+				Type:    "message",
+				ID:      b.itemID,
+				Role:    "assistant",
+				Status:  "completed",
+				Content: []responses.ResponseOutputMessageContentUnion{{Type: "refusal", Refusal: b.text.String()}},
+			}})
+		}
+	}
+	return synthetic
+}
+
+// fillMissingReasoning prepends the delta reasoning summary when the done
+// items did not include a reasoning item, so streamed thoughts are not
+// dropped from the persisted turn.
+func (a *streamAccumulator) fillMissingReasoning(r *model.LLMResponse) {
+	if a.reasoning.Len() == 0 {
+		return
+	}
+	for _, p := range r.Content.Parts {
+		if p.Thought {
+			return
+		}
+	}
+	r.Content.Parts = append(
+		[]*genai.Part{{Text: a.reasoning.String(), Thought: true}},
+		r.Content.Parts...,
+	)
+}
+
+// hasContent reports whether anything was accumulated that could be used to
+// rebuild a final response.
+func (a *streamAccumulator) hasContent() bool {
+	return a.reasoning.Len() > 0 || len(a.texts) > 0 || len(a.refusals) > 0 ||
+		len(a.functionCalls) > 0
+}
+
+// finalResponse builds a non-partial final response from the accumulated deltas
+// (for ADK to persist). The reasoning part precedes the answer part, which
+// precedes the tool calls, matching the temporal order in which they streamed.
+func (a *streamAccumulator) finalResponse(
+	finishReason genai.FinishReason,
+	usage *genai.GenerateContentResponseUsageMetadata,
+) *model.LLMResponse {
+	content := &genai.Content{Role: genai.RoleModel, Parts: []*genai.Part{}}
+	if a.reasoning.Len() > 0 {
+		content.Parts = append(content.Parts, &genai.Part{Text: a.reasoning.String(), Thought: true})
+	}
+	if text := joinDeltas(a.texts); text != "" {
+		content.Parts = append(content.Parts, &genai.Part{Text: text})
+	}
+	if refusal := joinDeltas(a.refusals); refusal != "" {
+		content.Parts = append(content.Parts, &genai.Part{
+			Text:         refusal,
+			PartMetadata: map[string]any{"refusal": true},
+		})
+	}
+	for _, fc := range a.functionCalls {
+		content.Parts = append(content.Parts, &genai.Part{FunctionCall: fc})
+	}
+	return &model.LLMResponse{
+		Content:       content,
+		UsageMetadata: usage,
+		FinishReason:  finishReason,
+		Partial:       false,
+		TurnComplete:  true,
+	}
+}
+
+// hasNoContent reports whether convertResponse produced no persistable content
+// parts, used to decide whether to fall back to the accumulated deltas.
+func hasNoContent(resp *model.LLMResponse) bool {
+	return resp == nil || resp.Content == nil || len(resp.Content.Parts) == 0
+}
+
+// buildResponseParams converts an LLMRequest into Responses API parameters.
+func (m *Model) buildResponseParams(req *model.LLMRequest) (responses.ResponseNewParams, error) {
+	params := responses.ResponseNewParams{
+		Model: shared.ResponsesModel(m.modelName),
+		// ADK owns the conversation state, so nothing needs to be stored
+		// server-side. store=false also makes the API return encrypted
+		// reasoning content (requested via include below), which is the only
+		// way to replay reasoning items in a stateless flow.
+		Store: param.NewOpt(false),
+		Include: []responses.ResponseIncludable{
+			responses.ResponseIncludableReasoningEncryptedContent,
+		},
+	}
+
+	// The system instruction maps to the instructions field.
+	if req.Config != nil && req.Config.SystemInstruction != nil {
+		if text := extractText(req.Config.SystemInstruction); text != "" {
+			params.Instructions = param.NewOpt(text)
+		}
+	}
+
+	// The conversation history maps to input items. Unpaired calls and
+	// outputs are dropped on the way: ADK histories can end mid-tool-call
+	// (cancel, compaction, agent switch), and the API rejects a
+	// function_call whose output never arrived, and the reverse.
+	dangling := danglingCallIDs(req.Contents)
+	var input responses.ResponseInputParam
+	for _, content := range req.Contents {
+		items, err := convertContentToInputItems(content, m.origin, dangling)
+		if err != nil {
+			return responses.ResponseNewParams{}, err
+		}
+		input = append(input, items...)
+	}
+	if len(input) > 0 {
+		params.Input.OfInputItemList = input
+	}
+
+	// Generation config
+	if req.Config != nil {
+		if err := applyGenerationConfig(&params, req.Config); err != nil {
+			return responses.ResponseNewParams{}, err
+		}
+	}
+
+	return params, nil
+}
+
+// applyGenerationConfig applies optional generation settings to the request params.
+func applyGenerationConfig(params *responses.ResponseNewParams, cfg *genai.GenerateContentConfig) error {
+	if cfg.Temperature != nil {
+		params.Temperature = param.NewOpt(float64(*cfg.Temperature))
+	}
+	if cfg.MaxOutputTokens > 0 {
+		params.MaxOutputTokens = param.NewOpt(int64(cfg.MaxOutputTokens))
+	}
+	if cfg.TopP != nil {
+		params.TopP = param.NewOpt(float64(*cfg.TopP))
+	}
+
+	// Reasoning (native support via Responses API)
+	if cfg.ThinkingConfig != nil {
+		params.Reasoning = shared.ReasoningParam{
+			Effort: convertThinkingLevel(cfg.ThinkingConfig.ThinkingLevel),
+		}
+		// Summaries are requested only when the caller wants thoughts
+		// surfaced; encrypted reasoning replay works without them.
+		if cfg.ThinkingConfig.IncludeThoughts {
+			params.Reasoning.Summary = shared.ReasoningSummaryAuto
+		}
+	}
+
+	// JSON mode
+	if cfg.ResponseMIMEType == "application/json" {
+		params.Text = responses.ResponseTextConfigParam{
+			Format: responses.ResponseFormatTextConfigUnionParam{
+				OfJSONObject: &shared.ResponseFormatJSONObjectParam{},
+			},
+		}
+	}
+
+	// Structured output with schema (also strict-normalised). Conversion
+	// errors are returned rather than swallowed: silently dropping the
+	// schema or the tools would send the request anyway and surface as
+	// inexplicable model behaviour.
+	if cfg.ResponseSchema != nil {
+		schemaMap, err := convertSchema(cfg.ResponseSchema)
+		if err != nil {
+			return fmt.Errorf("failed to convert response schema: %w", err)
+		}
+		// Strict mode requires an object root; a primitive or array root
+		// (which the typed schema allows) goes non-strict instead of
+		// building a request the API rejects.
+		strict := isObjectSchema(schemaMap)
+		if strict {
+			normalizeStrictSchema(schemaMap)
+		}
+		params.Text = responses.ResponseTextConfigParam{
+			Format: responses.ResponseFormatTextConfigUnionParam{
+				OfJSONSchema: &responses.ResponseFormatTextJSONSchemaConfigParam{
+					Name:        "response",
+					Description: param.NewOpt(cfg.ResponseSchema.Description),
+					Schema:      schemaMap,
+					Strict:      param.NewOpt(strict),
+				},
+			},
+		}
+	}
+
+	// A raw JSON schema (ResponseJsonSchema) goes through the same pipeline
+	// as tool parameters: strict when it fits the subset, non-strict
+	// otherwise, never silently ignored. The typed ResponseSchema wins when
+	// both are set.
+	if cfg.ResponseSchema == nil && cfg.ResponseJsonSchema != nil {
+		schemaMap, strict := convertFunctionParams(cfg.ResponseJsonSchema)
+		if schemaMap == nil {
+			return fmt.Errorf("response json schema cannot be converted to a JSON schema object")
+		}
+		// Strict response formats additionally require an object root.
+		if !isObjectSchema(schemaMap) {
+			strict = false
+		}
+		params.Text = responses.ResponseTextConfigParam{
+			Format: responses.ResponseFormatTextConfigUnionParam{
+				OfJSONSchema: &responses.ResponseFormatTextJSONSchemaConfigParam{
+					Name:   "response",
+					Schema: schemaMap,
+					Strict: param.NewOpt(strict),
+				},
+			},
+		}
+	}
+
+	// Tools
+	if len(cfg.Tools) > 0 {
+		tools, err := convertTools(cfg.Tools)
+		if err != nil {
+			return fmt.Errorf("failed to convert tools: %w", err)
+		}
+		params.Tools = tools
+	}
+
+	// ToolConfig maps to tool_choice.
+	if cfg.ToolConfig != nil && cfg.ToolConfig.FunctionCallingConfig != nil {
+		fcc := cfg.ToolConfig.FunctionCallingConfig
+		switch fcc.Mode {
+		case genai.FunctionCallingConfigModeAuto:
+			params.ToolChoice = responses.ResponseNewParamsToolChoiceUnion{
+				OfToolChoiceMode: param.NewOpt(responses.ToolChoiceOptionsAuto),
+			}
+		case genai.FunctionCallingConfigModeNone:
+			params.ToolChoice = responses.ResponseNewParamsToolChoiceUnion{
+				OfToolChoiceMode: param.NewOpt(responses.ToolChoiceOptionsNone),
+			}
+		case genai.FunctionCallingConfigModeAny:
+			if len(fcc.AllowedFunctionNames) == 1 {
+				params.ToolChoice = responses.ResponseNewParamsToolChoiceUnion{
+					OfFunctionTool: &responses.ToolChoiceFunctionParam{
+						Name: fcc.AllowedFunctionNames[0],
+					},
+				}
+			} else {
+				params.ToolChoice = responses.ResponseNewParamsToolChoiceUnion{
+					OfToolChoiceMode: param.NewOpt(responses.ToolChoiceOptionsRequired),
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// danglingCallIDs collects the IDs of function calls without a matching
+// output and outputs without a matching call across the whole history, so
+// the conversion can drop them: the API rejects both shapes.
+func danglingCallIDs(contents []*genai.Content) map[string]bool {
+	calls := map[string]bool{}
+	outputs := map[string]bool{}
+	for _, content := range contents {
+		if content == nil {
+			continue
+		}
+		for _, part := range content.Parts {
+			switch {
+			case part.FunctionCall != nil:
+				calls[part.FunctionCall.ID] = true
+			case part.FunctionResponse != nil:
+				outputs[part.FunctionResponse.ID] = true
+			}
+		}
+	}
+	dangling := map[string]bool{}
+	for id := range calls {
+		if !outputs[id] {
+			dangling[id] = true
+		}
+	}
+	for id := range outputs {
+		if !calls[id] {
+			dangling[id] = true
+		}
+	}
+	return dangling
+}
+
+// convertContentToInputItems converts a genai.Content into Responses API input items.
+// A single Content may produce multiple items: text/media coalesce into a message,
+// while FunctionCall and FunctionResponse become separate typed items. origin
+// identifies the requesting channel: encrypted reasoning is only replayed when
+// it was captured from the same origin. Parts whose call ID is in dangling
+// are skipped.
+func convertContentToInputItems(content *genai.Content, origin string, dangling map[string]bool) ([]responses.ResponseInputItemUnionParam, error) {
+	var items []responses.ResponseInputItemUnionParam
+	var textParts []string
+	var refusalFlags []bool
+	var mediaParts []responses.ResponseInputContentUnionParam
+	// orderedContents keeps text and media in their original interleaved
+	// order for mixed messages; regrouping them would change the prompt
+	// (e.g. which image a "describe the above" refers to).
+	var orderedContents responses.ResponseInputMessageContentListParam
+	var phase string
+	var messageID string
+	var msgStatus string
+	role := convertRole(content.Role)
+
+	// A replayed reasoning item must be followed by another item from the
+	// same turn (message or function call), or the API rejects it as
+	// dangling. Track the last part that produces such an item so trailing
+	// thoughts (e.g. from an interrupted turn) are not replayed.
+	lastFollower := -1
+	for i, part := range content.Parts {
+		if part.Thought {
+			continue
+		}
+		if part.FunctionCall != nil && dangling[part.FunctionCall.ID] {
+			continue
+		}
+		if part.FunctionResponse != nil && dangling[part.FunctionResponse.ID] {
+			continue
+		}
+		if part.FunctionCall != nil || part.FunctionResponse != nil ||
+			part.Text != "" || part.InlineData != nil || part.FileData != nil {
+			lastFollower = i
+		}
+	}
+
+	flushMessage := func() {
+		if len(textParts) == 0 && len(mediaParts) == 0 {
+			return
+		}
+
+		// Model output with a message ID or phase builds an OutputMessage
+		// manually, so the item identity survives the stateless round trip
+		// (models like gpt-5.3-codex expect phase back on every assistant
+		// message, and the API asks for output items to be replayed as-is).
+		// Output message content can only carry text and refusals, so a
+		// message that also holds media (possible in histories written by
+		// other adapters) keeps the media and gives up the identity via the
+		// content-list path instead of silently dropping parts.
+		if role == responses.EasyInputMessageRoleAssistant && (messageID != "" || phase != "") &&
+			len(mediaParts) == 0 {
+			var contentParts []responses.ResponseOutputMessageContentUnionParam
+			for i, t := range textParts {
+				if refusalFlags[i] {
+					contentParts = append(contentParts, responses.ResponseOutputMessageContentUnionParam{
+						OfRefusal: &responses.ResponseOutputRefusalParam{Refusal: t},
+					})
+					continue
+				}
+				contentParts = append(contentParts, responses.ResponseOutputMessageContentUnionParam{
+					OfOutputText: &responses.ResponseOutputTextParam{Text: t},
+				})
+			}
+			status := responses.ResponseOutputMessageStatusCompleted
+			if msgStatus != "" {
+				status = responses.ResponseOutputMessageStatus(msgStatus)
+			}
+			msg := responses.ResponseOutputMessageParam{
+				ID:      messageID,
+				Content: contentParts,
+				Status:  status,
+				Phase:   responses.ResponseOutputMessagePhase(phase),
+			}
+			items = append(items, responses.ResponseInputItemUnionParam{
+				OfOutputMessage: &msg,
+			})
+		} else if len(mediaParts) == 0 {
+			// Type is set explicitly: the OpenAPI spec discriminates input
+			// union items on it, even though the endpoint tolerates its
+			// absence.
+			items = append(items, responses.ResponseInputItemUnionParam{
+				OfMessage: &responses.EasyInputMessageParam{
+					Content: responses.EasyInputMessageContentUnionParam{
+						OfString: param.NewOpt(joinTexts(textParts)),
+					},
+					Role: role,
+					Type: responses.EasyInputMessageTypeMessage,
+				},
+			})
+		} else {
+			// Only the message ID has no field on this path; the phase does
+			// (models like gpt-5.3-codex expect it back), so it is kept.
+			// Phase is assistant-only: multi-agent histories relabel other
+			// agents' output as user while keeping part metadata, and the
+			// API rejects phase on user messages.
+			msgPhase := responses.EasyInputMessagePhase("")
+			if role == responses.EasyInputMessageRoleAssistant {
+				msgPhase = responses.EasyInputMessagePhase(phase)
+			}
+			items = append(items, responses.ResponseInputItemUnionParam{
+				OfMessage: &responses.EasyInputMessageParam{
+					Phase: msgPhase,
+					Content: responses.EasyInputMessageContentUnionParam{
+						OfInputItemContentList: orderedContents,
+					},
+					Role: role,
+					Type: responses.EasyInputMessageTypeMessage,
+				},
+			})
+		}
+
+		textParts = nil
+		refusalFlags = nil
+		mediaParts = nil
+		orderedContents = nil
+		phase = ""
+		messageID = ""
+		msgStatus = ""
+	}
+
+	for i, part := range content.Parts {
+		switch {
+		case part.FunctionResponse != nil:
+			if dangling[part.FunctionResponse.ID] {
+				continue
+			}
+			flushMessage()
+			responseJSON, err := common.MarshalToolPayload(part.FunctionResponse.Response)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal function response: %w", err)
+			}
+			items = append(items, responses.ResponseInputItemParamOfFunctionCallOutput(
+				part.FunctionResponse.ID, string(responseJSON),
+			))
+
+		case part.FunctionCall != nil:
+			if dangling[part.FunctionCall.ID] {
+				continue
+			}
+			flushMessage()
+			argsJSON, err := common.MarshalToolPayload(part.FunctionCall.Args)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal function args: %w", err)
+			}
+			items = append(items, responses.ResponseInputItemParamOfFunctionCall(
+				string(argsJSON), part.FunctionCall.ID, part.FunctionCall.Name,
+			))
+
+		case part.Thought:
+			// Reasoning items carrying encrypted content are replayed so the
+			// model keeps its chain of thought across turns; reasoning models
+			// require the reasoning item preceding a function_call to be
+			// present in the input. Skipped instead of replayed when:
+			//   - the content is not an assistant turn: in multi-agent
+			//     histories another agent's output (thoughts included) shows
+			//     up under other roles, where a reasoning item is invalid;
+			//   - there is no encrypted content (e.g. gateways that ignore
+			//     the include parameter): bare IDs only resolve in the
+			//     originating response and replaying them is a 400;
+			//   - the origin does not match: encrypted content is bound to
+			//     the provider/API key/model that produced it, and replaying
+			//     it elsewhere is a 400 invalid_encrypted_content;
+			//   - no item from the same turn follows: the API rejects
+			//     dangling reasoning items.
+			// Skipping degrades gracefully: the model re-derives its
+			// reasoning for the turn instead of the request failing.
+			if role != responses.EasyInputMessageRoleAssistant {
+				continue
+			}
+			enc, _ := part.PartMetadata["encrypted_content"].(string)
+			id, _ := part.PartMetadata["reasoning_id"].(string)
+			if enc == "" || id == "" {
+				continue
+			}
+			if partOrigin, _ := part.PartMetadata["reasoning_origin"].(string); origin == "" || partOrigin != origin {
+				continue
+			}
+			if i > lastFollower {
+				continue
+			}
+			flushMessage()
+			reasoning := responses.ResponseReasoningItemParam{
+				ID:               id,
+				Summary:          []responses.ResponseReasoningItemSummaryParam{},
+				EncryptedContent: param.NewOpt(enc),
+			}
+			if part.Text != "" {
+				reasoning.Summary = append(reasoning.Summary,
+					responses.ResponseReasoningItemSummaryParam{Text: part.Text})
+			}
+			items = append(items, responses.ResponseInputItemUnionParam{
+				OfReasoning: &reasoning,
+			})
+
+		case part.Text != "":
+			// Parts from different output messages must not coalesce:
+			// flushing on a message_id or phase change keeps each replayed
+			// message's identity and phase intact (models like
+			// gpt-5.3-codex expect commentary and final answer separate).
+			// Only buffered text marks a boundary: identity comes from text
+			// parts alone, so a media-only prefix has none yet and adopts
+			// the incoming identity instead of splitting off the media.
+			partID, _ := part.PartMetadata["message_id"].(string)
+			partPhase, _ := part.PartMetadata["phase"].(string)
+			if len(textParts) > 0 &&
+				(partID != messageID || partPhase != phase) {
+				flushMessage()
+			}
+			messageID = partID
+			phase = partPhase
+			if s, ok := part.PartMetadata["status"].(string); ok && s != "" {
+				msgStatus = s
+			}
+			refusal, _ := part.PartMetadata["refusal"].(bool)
+			refusalFlags = append(refusalFlags, refusal)
+			textParts = append(textParts, part.Text)
+			orderedContents = append(orderedContents, responses.ResponseInputContentParamOfInputText(part.Text))
+
+		case part.InlineData != nil:
+			p, err := convertInlineDataToPart(part.InlineData)
+			if err != nil {
+				return nil, err
+			}
+			mediaParts = append(mediaParts, *p)
+			orderedContents = append(orderedContents, *p)
+
+		case part.FileData != nil:
+			p, err := convertFileDataToPart(part.FileData)
+			if err != nil {
+				return nil, err
+			}
+			mediaParts = append(mediaParts, *p)
+			orderedContents = append(orderedContents, *p)
+		}
+	}
+
+	flushMessage()
+	return items, nil
+}
+
+// convertResponse transforms a Responses API response into an LLMResponse.
+// origin identifies the channel that produced the response; it is recorded
+// alongside encrypted reasoning content so replay can be restricted to the
+// same channel.
+func convertResponse(resp *responses.Response, origin string) (*model.LLMResponse, error) {
+	// A failed response is an error, mirroring the streaming response.failed
+	// handling: without this check the server's message would degrade into
+	// "no output items", or partial output would pass as a completed turn.
+	if resp.Status == responses.ResponseStatusFailed {
+		msg := resp.Error.Message
+		if msg == "" {
+			msg = string(resp.Error.Code)
+		}
+		if msg == "" {
+			msg = "response generation failed"
+		}
+		return nil, fmt.Errorf("openai responses api: %s", msg)
+	}
+	if len(resp.Output) == 0 {
+		return nil, ErrNoOutputInResponse
+	}
+
+	content := &genai.Content{
+		Role:  genai.RoleModel,
+		Parts: []*genai.Part{},
+	}
+
+	itemTypes := map[string]bool{}
+	for _, item := range resp.Output {
+		itemTypes[item.Type] = true
+		switch item.Type {
+		case "reasoning":
+			// One part per reasoning item, even when the summary is empty:
+			// the encrypted content must survive the round-trip through ADK
+			// history so the item can be replayed on the next turn.
+			var summaryTexts []string
+			for _, summary := range item.Summary {
+				if summary.Text != "" {
+					summaryTexts = append(summaryTexts, summary.Text)
+				}
+			}
+			if len(summaryTexts) == 0 && item.EncryptedContent == "" {
+				continue
+			}
+			meta := map[string]any{"reasoning_id": item.ID}
+			if item.EncryptedContent != "" {
+				meta["encrypted_content"] = item.EncryptedContent
+				meta["reasoning_origin"] = origin
+			}
+			content.Parts = append(content.Parts, &genai.Part{
+				Text:         joinTexts(summaryTexts),
+				Thought:      true,
+				PartMetadata: meta,
+			})
+
+		case "message":
+			// ID, phase, status, and the refusal flag are kept per part so
+			// the message replays with its identity intact instead of
+			// degrading to plain completed output_text.
+			meta := func(refusal bool) map[string]any {
+				m := map[string]any{}
+				if item.Phase != "" {
+					m["phase"] = string(item.Phase)
+				}
+				if item.ID != "" {
+					m["message_id"] = item.ID
+				}
+				if item.Status != "" {
+					m["status"] = string(item.Status)
+				}
+				if refusal {
+					m["refusal"] = true
+				}
+				if len(m) == 0 {
+					return nil
+				}
+				return m
+			}
+			for _, cp := range item.Content {
+				switch cp.Type {
+				case "output_text":
+					content.Parts = append(content.Parts, &genai.Part{
+						Text: cp.Text, PartMetadata: meta(false),
+					})
+				case "refusal":
+					content.Parts = append(content.Parts, &genai.Part{
+						Text: cp.Refusal, PartMetadata: meta(true),
+					})
+				}
+			}
+
+		case "function_call":
+			args, err := parseJSONArgs(item.Arguments.OfString)
+			if err != nil {
+				return nil, err
+			}
+			content.Parts = append(content.Parts, &genai.Part{
+				FunctionCall: &genai.FunctionCall{
+					ID:   item.CallID,
+					Name: item.Name,
+					Args: args,
+				},
+			})
+		}
+	}
+
+	// Unknown item types are skipped for forward compatibility, but when
+	// nothing consumable remains the turn must not pass as completed: ADK
+	// would persist an empty event with no clue about what was dropped.
+	if len(content.Parts) == 0 {
+		return nil, fmt.Errorf("%w (item types: %s)", ErrNoConsumableOutput, joinSortedKeys(itemTypes))
+	}
+
+	return &model.LLMResponse{
+		Content:       content,
+		UsageMetadata: convertUsageMetadata(resp.Usage),
+		FinishReason:  convertStatus(resp.Status, resp.IncompleteDetails),
+		TurnComplete:  true,
+	}, nil
+}
+
+// convertTools transforms genai tools into Responses API function tool format.
+func convertTools(genaiTools []*genai.Tool) ([]responses.ToolUnionParam, error) {
+	var tools []responses.ToolUnionParam
+
+	for _, genaiTool := range genaiTools {
+		if genaiTool == nil {
+			continue
+		}
+
+		// Tool facets other than function declarations (GoogleSearch,
+		// CodeExecution, ...) have no Responses API mapping; failing loud
+		// beats silently sending no tool at all.
+		rest := *genaiTool
+		rest.FunctionDeclarations = nil
+		if data, err := json.Marshal(rest); err == nil && string(data) != "{}" {
+			return nil, fmt.Errorf("unsupported tool fields for the Responses API: %s", data)
+		}
+
+		for _, funcDecl := range genaiTool.FunctionDeclarations {
+			params := funcDecl.ParametersJsonSchema
+			// Assign only a non-nil *genai.Schema: a nil pointer stored in
+			// the interface would defeat the nil check that gives
+			// parameterless tools a valid empty object schema.
+			if params == nil && funcDecl.Parameters != nil {
+				params = funcDecl.Parameters
+			}
+
+			toolParams, strict := convertFunctionParams(params)
+			if toolParams == nil {
+				return nil, fmt.Errorf("parameters of tool %q cannot be converted to a JSON schema object", funcDecl.Name)
+			}
+
+			tools = append(tools, responses.ToolUnionParam{
+				OfFunction: &responses.FunctionToolParam{
+					Name:        funcDecl.Name,
+					Description: param.NewOpt(funcDecl.Description),
+					Parameters:  toolParams,
+					Strict:      param.NewOpt(strict),
+				},
+			})
+		}
+	}
+
+	return tools, nil
+}
+
+// --- Helper functions ---
+
+// convertInlineDataToPart converts inline data to the appropriate Responses
+// API content part. Images become input_image data URIs and documents become
+// input_file data; audio is rejected because the API's file inputs do not
+// accept it.
+func convertInlineDataToPart(data *genai.Blob) (*responses.ResponseInputContentUnionParam, error) {
+	if data == nil {
+		return nil, fmt.Errorf("inline data is nil")
+	}
+
+	mediaType := normalizeMIMEType(data.MIMEType)
+	base64Data := base64.StdEncoding.EncodeToString(data.Data)
+	dataURI := fmt.Sprintf("data:%s;base64,%s", mediaType, base64Data)
+
+	switch {
+	case mediaType == "image/jpeg" || mediaType == "image/jpg" || mediaType == "image/png" ||
+		mediaType == "image/gif" || mediaType == "image/webp":
+		return &responses.ResponseInputContentUnionParam{
+			OfInputImage: &responses.ResponseInputImageParam{
+				ImageURL: param.NewOpt(dataURI),
+				Detail:   responses.ResponseInputImageDetailAuto,
+			},
+		}, nil
+
+	case isDocumentMIMEType(mediaType):
+		// Base64 file uploads need a filename with an extension: the API
+		// identifies the document type by it. The caller's DisplayName
+		// wins; a missing extension is filled in from the MIME type, and
+		// types without an unambiguous extension require a DisplayName.
+		filename := data.DisplayName
+		if path.Ext(filename) == "" {
+			ext := extensionForMIME(mediaType)
+			if ext == "" {
+				return nil, fmt.Errorf("no filename extension can be derived for MIME type %s: set DisplayName to a filename with an extension", mediaType)
+			}
+			if filename == "" {
+				filename = "input"
+			}
+			filename += "." + ext
+		}
+		return &responses.ResponseInputContentUnionParam{
+			OfInputFile: &responses.ResponseInputFileParam{
+				FileData: param.NewOpt(dataURI),
+				Filename: param.NewOpt(filename),
+			},
+		}, nil
+
+	case strings.HasPrefix(mediaType, "audio/"):
+		// The API's file inputs accept no audio and the SDK's input
+		// content union has no input_audio member, so audio is rejected
+		// instead of being sent as a file the server will refuse.
+		return nil, fmt.Errorf("audio input is not supported by the Responses API adapter: %s", mediaType)
+
+	default:
+		return nil, fmt.Errorf("unsupported inline data MIME type for Responses API: %s", mediaType)
+	}
+}
+
+// isDocumentMIMEType reports whether a media type is in the Responses API's
+// documented file-input list: text/ wholesale, plus the documented
+// application/ and message/ types (documents, spreadsheets, presentations,
+// and code carriers).
+func isDocumentMIMEType(mediaType string) bool {
+	if strings.HasPrefix(mediaType, "text/") {
+		return true
+	}
+	switch mediaType {
+	case "application/pdf",
+		"message/rfc822",
+		// Spreadsheets.
+		"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+		"application/vnd.ms-excel",
+		"application/csv",
+		"application/x-iif",
+		"application/vnd.google-apps.spreadsheet",
+		// Rich documents.
+		"application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+		"application/msword",
+		"application/rtf",
+		"application/vnd.oasis.opendocument.text",
+		"application/vnd.apple.pages",
+		"application/vnd.google-apps.document",
+		"application/vnd.apple.iwork",
+		// Presentations.
+		"application/vnd.openxmlformats-officedocument.presentationml.presentation",
+		"application/vnd.ms-powerpoint",
+		"application/vnd.apple.keynote",
+		"application/vnd.google-apps.presentation",
+		// Code and structured text.
+		"application/javascript",
+		"application/typescript",
+		"application/json",
+		"application/json5",
+		"application/x-json5",
+		"application/x-ndjson",
+		"application/yaml",
+		"application/x-yaml",
+		"application/toml",
+		"application/x-toml",
+		"application/graphql",
+		"application/x-graphql",
+		"application/x-protobuf",
+		"application/x-sql",
+		"application/x-scala",
+		"application/x-rust",
+		"application/x-php",
+		"application/x-httpd-php",
+		"application/x-httpd-php-source",
+		"application/x-powershell",
+		"application/x-bash",
+		"application/x-awk",
+		"application/x-terraform",
+		"application/x-patch",
+		"application/x-subrip":
+		return true
+	}
+	return false
+}
+
+// convertFileDataToPart maps a FileData part to a content part; the URI goes
+// through verbatim, nothing is downloaded. Images become input_image and
+// documents become input_file with file_url; audio has no URL transport in
+// the API. Plain http is allowed for API-compatible gateways. Other schemes
+// error instead of being silently dropped; gs://, the scheme genai.FileData
+// documents, gets its own message pointing at InlineData. DisplayName is
+// dropped: neither part has a field for it.
+func convertFileDataToPart(data *genai.FileData) (*responses.ResponseInputContentUnionParam, error) {
+	if data == nil {
+		return nil, fmt.Errorf("file data is nil")
+	}
+	if strings.HasPrefix(data.FileURI, "gs://") {
+		return nil, fmt.Errorf("file data URI %q is a Google Cloud Storage URI, which the Responses API cannot fetch: download the bytes and use InlineData instead", data.FileURI)
+	}
+	if !strings.HasPrefix(data.FileURI, "https://") && !strings.HasPrefix(data.FileURI, "http://") {
+		return nil, fmt.Errorf("file data URI must be an http(s) URL for the Responses API, got %q", data.FileURI)
+	}
+
+	mediaType := normalizeMIMEType(data.MIMEType)
+	switch {
+	case mediaType == "image/jpeg" || mediaType == "image/jpg" || mediaType == "image/png" ||
+		mediaType == "image/gif" || mediaType == "image/webp":
+		return &responses.ResponseInputContentUnionParam{
+			OfInputImage: &responses.ResponseInputImageParam{
+				ImageURL: param.NewOpt(data.FileURI),
+				Detail:   responses.ResponseInputImageDetailAuto,
+			},
+		}, nil
+
+	case isDocumentMIMEType(mediaType):
+		return &responses.ResponseInputContentUnionParam{
+			OfInputFile: &responses.ResponseInputFileParam{
+				FileURL: param.NewOpt(data.FileURI),
+			},
+		}, nil
+
+	case strings.HasPrefix(mediaType, "audio/"):
+		return nil, fmt.Errorf("audio input is not supported by the Responses API adapter: %s", mediaType)
+
+	default:
+		return nil, fmt.Errorf("unsupported file data MIME type for Responses API: %s", mediaType)
+	}
+}
+
+// extensionForMIME derives a filename extension for base64 file uploads.
+// Types whose subtype is not a usable extension are mapped explicitly; the
+// rest use the subtype with "x-" and "vnd." prefixes stripped. An empty
+// result marks a type with no unambiguous extension (e.g. iWork, which
+// covers both Pages and Keynote), where the caller must name the file.
+func extensionForMIME(mediaType string) string {
+	switch mediaType {
+	case "text/plain":
+		return "txt"
+	case "text/markdown":
+		return "md"
+	case "application/javascript", "text/javascript":
+		return "js"
+	case "application/typescript", "text/x-typescript":
+		return "ts"
+	case "text/x-python", "text/x-script.python":
+		return "py"
+	case "text/x-c":
+		return "c"
+	case "text/x-c++":
+		return "cpp"
+	case "text/x-csharp":
+		return "cs"
+	case "text/x-golang":
+		return "go"
+	case "text/x-ruby":
+		return "rb"
+	case "text/x-rust", "application/x-rust":
+		return "rs"
+	case "text/x-shellscript", "application/x-bash":
+		return "sh"
+	case "text/x-perl":
+		return "pl"
+	case "text/x-kotlin":
+		return "kt"
+	case "message/rfc822":
+		return "eml"
+	case "application/msword":
+		return "doc"
+	case "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
+		return "docx"
+	case "application/vnd.ms-excel":
+		return "xls"
+	case "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet":
+		return "xlsx"
+	case "application/vnd.ms-powerpoint":
+		return "ppt"
+	case "application/vnd.openxmlformats-officedocument.presentationml.presentation":
+		return "pptx"
+	case "application/vnd.oasis.opendocument.text":
+		return "odt"
+	case "application/vnd.apple.pages":
+		return "pages"
+	case "application/vnd.apple.keynote":
+		return "key"
+	case "application/vnd.apple.iwork":
+		return ""
+	case "application/x-ndjson":
+		return "ndjson"
+	case "application/x-subrip":
+		return "srt"
+	case "application/x-httpd-php", "application/x-httpd-php-source":
+		return "php"
+	case "application/x-protobuf":
+		return "proto"
+	case "application/x-terraform":
+		return "tf"
+	case "application/x-powershell":
+		return "ps1"
+	case "application/graphql", "application/x-graphql":
+		return "graphql"
+	}
+	sub := mediaType[strings.LastIndexByte(mediaType, '/')+1:]
+	sub = strings.TrimPrefix(sub, "x-")
+	sub = strings.TrimPrefix(sub, "vnd.")
+	if strings.ContainsAny(sub, "./+") {
+		return ""
+	}
+	return sub
+}
+
+// normalizeMIMEType strips parameters from a MIME string ("image/png;
+// charset=utf-8" becomes "image/png") so the converters match on the media
+// type alone. Malformed strings come back unchanged and fail the match with
+// the caller's input in the error.
+func normalizeMIMEType(mimeType string) string {
+	mediaType, _, err := mime.ParseMediaType(mimeType)
+	if err != nil {
+		return mimeType
+	}
+	return mediaType
+}
+
+// convertUsageMetadata converts Responses API usage stats to genai format.
+func convertUsageMetadata(usage responses.ResponseUsage) *genai.GenerateContentResponseUsageMetadata {
+	if usage.TotalTokens == 0 {
+		return nil
+	}
+	return &genai.GenerateContentResponseUsageMetadata{
+		PromptTokenCount:        int32(usage.InputTokens),
+		CandidatesTokenCount:    int32(usage.OutputTokens),
+		TotalTokenCount:         int32(usage.TotalTokens),
+		ThoughtsTokenCount:      int32(usage.OutputTokensDetails.ReasoningTokens),
+		CachedContentTokenCount: int32(usage.InputTokensDetails.CachedTokens),
+	}
+}
+
+// convertRole maps genai roles to Responses API EasyInputMessageRole. The
+// literal "assistant" appears in histories written by other adapters and
+// must not degrade to a user message.
+func convertRole(role string) responses.EasyInputMessageRole {
+	switch role {
+	case "model", "assistant":
+		return responses.EasyInputMessageRoleAssistant
+	case "system":
+		return responses.EasyInputMessageRoleSystem
+	default:
+		return responses.EasyInputMessageRoleUser
+	}
+}
+
+// convertStatus maps Responses API status to genai finish reason.
+func convertStatus(status responses.ResponseStatus, details responses.ResponseIncompleteDetails) genai.FinishReason {
+	switch status {
+	case responses.ResponseStatusCompleted:
+		return genai.FinishReasonStop
+	case responses.ResponseStatusIncomplete:
+		switch details.Reason {
+		case "max_output_tokens":
+			return genai.FinishReasonMaxTokens
+		case "content_filter":
+			return genai.FinishReasonSafety
+		}
+		return genai.FinishReasonUnspecified
+	default:
+		return genai.FinishReasonUnspecified
+	}
+}
+
+// convertThinkingLevel maps genai thinking levels to Responses API reasoning effort.
+func convertThinkingLevel(level genai.ThinkingLevel) shared.ReasoningEffort {
+	switch level {
+	case genai.ThinkingLevelMinimal:
+		return shared.ReasoningEffortMinimal
+	case genai.ThinkingLevelLow:
+		return shared.ReasoningEffortLow
+	case genai.ThinkingLevelHigh:
+		return shared.ReasoningEffortHigh
+	default:
+		return shared.ReasoningEffortMedium
+	}
+}
+
+// convertToStrictFunctionParams converts various parameter types to a map
+// compliant with OpenAI strict mode. A nil input produces a valid empty
+// object schema so parameterless tools are accepted. The input is deep-copied
+// via JSON round-trip to avoid mutating the caller's schema.
+func convertToStrictFunctionParams(params any) map[string]any {
+	if params == nil {
+		return map[string]any{
+			"type":                 "object",
+			"properties":           map[string]any{},
+			"required":             []any{},
+			"additionalProperties": false,
+		}
+	}
+
+	m := deepCopySchema(params)
+	if m == nil {
+		return nil
+	}
+
+	lowercaseTypes(m)
+	normalizeStrictSchema(m)
+	return m
+}
+
+// convertFunctionParams prepares tool parameters for the API and decides the
+// strict flag. Schemas inside the strict subset are normalized and sent with
+// strict=true so the API constrains generation to them. Schemas the subset
+// cannot express, such as free-form objects (additionalProperties: true) or
+// arrays without an item schema, are sent as authored with strict=false:
+// forcing them through strict normalization would silently change their
+// meaning (a free-form object would harden into an empty one), and the API
+// rejects them with invalid_function_parameters if sent strict anyway.
+func convertFunctionParams(params any) (map[string]any, bool) {
+	if params == nil {
+		return convertToStrictFunctionParams(nil), true
+	}
+	m := deepCopySchema(params)
+	if m == nil {
+		return nil, false
+	}
+	lowercaseTypes(m)
+	m = inlineRootRef(m)
+	// Strict mode requires the root to be a plain object: a root that is
+	// still a $ref, an array, or a union goes non-strict as-is. anyOf and
+	// oneOf are both checked because normalization would rename a root
+	// oneOf into the anyOf the API rejects at the root.
+	if !isObjectSchema(m) {
+		return m, false
+	}
+	for _, key := range []string{"anyOf", "oneOf"} {
+		if _, ok := m[key]; ok {
+			return m, false
+		}
+	}
+	if !fitsStrictSubset(m) {
+		return m, false
+	}
+	normalizeStrictSchema(m)
+	return m, true
+}
+
+// inlineRootRef resolves the root-level "$ref plus $defs" shape that Go
+// schema generators commonly emit. Strict mode wants the root to be a plain
+// object, so the referenced definition's keys are copied onto the root and
+// $defs stays for the remaining references. Roots with extra siblings or an
+// unresolvable pointer come back unchanged and fail the object check.
+func inlineRootRef(m map[string]any) map[string]any {
+	ref, ok := m["$ref"].(string)
+	if !ok {
+		return m
+	}
+	for key := range m {
+		if key != "$ref" && key != "$defs" {
+			return m
+		}
+	}
+	name, found := strings.CutPrefix(ref, "#/$defs/")
+	if !found || strings.Contains(name, "/") {
+		return m
+	}
+	defs, _ := m["$defs"].(map[string]any)
+	target, ok := defs[name].(map[string]any)
+	if !ok {
+		return m
+	}
+	if _, hasOwnDefs := target["$defs"]; hasOwnDefs {
+		return m
+	}
+	// The target is copied so the root and the $defs entry do not share
+	// maps during normalization.
+	root := deepCopySchema(target)
+	if root == nil {
+		return m
+	}
+	root["$defs"] = defs
+	return root
+}
+
+// unsupportedStrictKeywords are schema keywords the strict subset rejects and
+// normalization cannot express or rewrite. Their presence anywhere in a tool
+// schema sends the tool as non-strict. oneOf is absent on purpose: it is
+// rewritten to anyOf during normalization.
+var unsupportedStrictKeywords = []string{
+	"allOf", "not", "if", "then", "else",
+	"dependentRequired", "dependentSchemas", "patternProperties",
+	"propertyNames", "prefixItems", "contains", "unevaluatedProperties",
+	"minLength", "maxLength",
+}
+
+// fitsStrictSubset reports whether a schema can be normalized into the strict
+// subset without changing what it accepts. It walks the same nodes as
+// normalizeStrictSchema and fails on free-form objects, arrays without an
+// item schema, nodes whose type cannot be derived, and keywords the subset
+// rejects outright.
+func fitsStrictSubset(schema map[string]any) bool {
+	for _, key := range unsupportedStrictKeywords {
+		if _, ok := schema[key]; ok {
+			return false
+		}
+	}
+
+	if ap, ok := schema["additionalProperties"]; ok && ap != false {
+		return false
+	}
+
+	// A $ref next to anyOf or oneOf is a conjunction the strict subset
+	// cannot express: hoisting the reference into the union would change
+	// what the schema accepts, so such nodes go non-strict.
+	if _, ok := schema["$ref"]; ok {
+		for _, key := range []string{"anyOf", "oneOf"} {
+			if _, exists := schema[key]; exists {
+				return false
+			}
+		}
+	}
+
+	if isArraySchema(schema) {
+		if _, ok := schema["items"]; !ok {
+			return false
+		}
+	}
+
+	if !hasDerivableType(schema) {
+		return false
+	}
+
+	if props, ok := schema["properties"].(map[string]any); ok {
+		for _, prop := range props {
+			if propMap, ok := prop.(map[string]any); ok && !fitsStrictSubset(propMap) {
+				return false
+			}
+		}
+	}
+	if items, ok := schema["items"].(map[string]any); ok && !fitsStrictSubset(items) {
+		return false
+	}
+	if defs, ok := schema["$defs"].(map[string]any); ok {
+		for _, def := range defs {
+			if defMap, ok := def.(map[string]any); ok && !fitsStrictSubset(defMap) {
+				return false
+			}
+		}
+	}
+	for _, key := range []string{"anyOf", "oneOf"} {
+		branches, _ := schema[key].([]any)
+		for _, branch := range branches {
+			if branchMap, ok := branch.(map[string]any); ok && !fitsStrictSubset(branchMap) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// hasDerivableType reports whether a node either has a type or lets strict
+// normalization derive one: $ref and union nodes need no type of their own,
+// object and array shapes are recognized from properties/items, and literal
+// nodes derive their type from const or enum values.
+func hasDerivableType(schema map[string]any) bool {
+	if _, ok := schema["type"]; ok {
+		return true
+	}
+	if _, ok := schema["$ref"]; ok {
+		return true
+	}
+	for _, key := range []string{"anyOf", "oneOf"} {
+		if _, ok := schema[key]; ok {
+			return true
+		}
+	}
+	if isObjectSchema(schema) {
+		return true
+	}
+	if _, ok := schema["items"]; ok {
+		return true
+	}
+	if v, ok := schema["const"]; ok {
+		return literalType(v) != ""
+	}
+	if vals, ok := schema["enum"].([]any); ok && len(vals) > 0 {
+		t := literalType(vals[0])
+		if t == "" {
+			return false
+		}
+		for _, v := range vals[1:] {
+			if literalType(v) != t {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
+// isArraySchema reports whether the schema's type names "array", either as a
+// plain string or inside a type union list.
+func isArraySchema(schema map[string]any) bool {
+	switch t := schema["type"].(type) {
+	case string:
+		return t == "array"
+	case []any:
+		for _, v := range t {
+			if s, ok := v.(string); ok && s == "array" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// normalizeStrictSchema recursively makes a JSON schema compliant with
+// OpenAI strict mode. For every object type (whether type is "object" or
+// contains "object" in an array like ["object", "null"]) it:
+//   - adds "additionalProperties": false
+//   - ensures "properties" exists
+//   - sets "required" to all property keys
+//   - expands originally-optional properties to nullable (["type", "null"])
+//
+// Recursion covers properties, items, $defs and anyOf branches, oneOf keys
+// are renamed to anyOf (the strict subset rejects oneOf), and bare const or
+// enum nodes get their literal type filled in. Child schemas
+// are normalised before the parent marks optional fields as nullable, so
+// nested objects get their own required/additionalProperties regardless of
+// whether the parent considers them optional.
+func normalizeStrictSchema(schema map[string]any) {
+	if schema == nil {
+		return
+	}
+
+	// Recurse into children first so nested objects are fully normalised
+	// before we decide which parent-level fields are optional.
+	if props, ok := schema["properties"].(map[string]any); ok {
+		for _, prop := range props {
+			if propMap, ok := prop.(map[string]any); ok {
+				normalizeStrictSchema(propMap)
+			}
+		}
+	}
+	if items, ok := schema["items"].(map[string]any); ok {
+		normalizeStrictSchema(items)
+	}
+	ensureTypeForLiteral(schema)
+	if _, ok := schema["type"]; !ok {
+		if _, hasItems := schema["items"]; hasItems {
+			schema["type"] = "array"
+		}
+	}
+	if defs, ok := schema["$defs"].(map[string]any); ok {
+		for _, def := range defs {
+			if defMap, ok := def.(map[string]any); ok {
+				normalizeStrictSchema(defMap)
+			}
+		}
+	}
+
+	// The strict subset rejects "oneOf", so the key is renamed to anyOf.
+	// This widens validation from "exactly one branch" to "at least one
+	// branch": every payload the original schema accepted stays valid, so
+	// generation keeps following the authored branches. In the rare case
+	// where anyOf is already present the oneOf branches are dropped, as
+	// the subset has no way to express the conjunction of the two.
+	if branches, ok := schema["oneOf"].([]any); ok {
+		if _, exists := schema["anyOf"]; !exists {
+			schema["anyOf"] = branches
+		}
+		delete(schema, "oneOf")
+	}
+
+	// The strict validator rejects a $ref with sibling keys, so the
+	// reference moves into a single-branch anyOf while the siblings stay
+	// on the node: annotations and constraints keep applying alongside
+	// the reference instead of being dropped.
+	if ref, ok := schema["$ref"]; ok && len(schema) > 1 {
+		if _, exists := schema["anyOf"]; !exists {
+			delete(schema, "$ref")
+			schema["anyOf"] = []any{map[string]any{"$ref": ref}}
+		}
+	}
+
+	if branches, ok := schema["anyOf"].([]any); ok {
+		for _, branch := range branches {
+			if branchMap, ok := branch.(map[string]any); ok {
+				normalizeStrictSchema(branchMap)
+			}
+		}
+	}
+
+	// OpenAPI-style "nullable" is not a JSON Schema keyword and the strict
+	// validator rejects it; it converts faithfully to a null type union.
+	if v, ok := schema["nullable"]; ok {
+		if b, _ := v.(bool); b {
+			makeNullable(schema)
+		}
+		delete(schema, "nullable")
+	}
+
+	if !isObjectSchema(schema) {
+		return
+	}
+
+	if _, ok := schema["type"]; !ok {
+		schema["type"] = "object"
+	}
+
+	if _, hasProps := schema["properties"]; !hasProps {
+		schema["properties"] = map[string]any{}
+	}
+	schema["additionalProperties"] = false
+
+	props, _ := schema["properties"].(map[string]any)
+	existing := toStringSet(schema["required"])
+	allKeys := make([]any, 0, len(props))
+	for key := range props {
+		allKeys = append(allKeys, key)
+		if !existing[key] {
+			makeNullable(props[key])
+		}
+	}
+	// Sort for a deterministic order: map iteration is randomised, and an
+	// unstable "required" array changes the serialized tool definition on
+	// every request, which breaks OpenAI prompt-cache prefix matching.
+	sort.Slice(allKeys, func(i, j int) bool {
+		return allKeys[i].(string) < allKeys[j].(string)
+	})
+	schema["required"] = allKeys
+}
+
+// isObjectSchema returns true if the schema represents an object, either
+// by explicit type or by having a "properties" field (common in dynamically
+// registered tools that omit "type").
+func isObjectSchema(schema map[string]any) bool {
+	if isObjectType(schema) {
+		return true
+	}
+	_, hasProps := schema["properties"]
+	return hasProps
+}
+
+// isObjectType returns true if the schema's "type" is "object", either as a
+// plain string or inside an array (e.g. ["object", "null"]).
+func isObjectType(schema map[string]any) bool {
+	switch t := schema["type"].(type) {
+	case string:
+		return t == "object"
+	case []any:
+		for _, v := range t {
+			if s, ok := v.(string); ok && s == "object" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// makeNullable expands a property's type to ["<original>", "null"] so strict
+// mode accepts it as an optional (nullable) field. Properties without a
+// "type" key ($ref, typeless anyOf unions) get a null branch instead.
+// ensureTypeForLiteral fills in a missing "type" on schemas written as a
+// bare const or enum. The API rejects such nodes with "schema must have a
+// 'type' key", and the type of a literal follows from its value, so it is
+// derived from the const or from a same-typed enum value list.
+func ensureTypeForLiteral(schema map[string]any) {
+	if _, ok := schema["type"]; ok {
+		return
+	}
+	if v, ok := schema["const"]; ok {
+		if t := literalType(v); t != "" {
+			schema["type"] = t
+		}
+		return
+	}
+	if vals, ok := schema["enum"].([]any); ok && len(vals) > 0 {
+		t := literalType(vals[0])
+		for _, v := range vals[1:] {
+			if literalType(v) != t {
+				return
+			}
+		}
+		if t != "" {
+			schema["type"] = t
+		}
+	}
+}
+
+// literalType maps a decoded JSON literal to its schema type name. An empty
+// string means the type cannot be derived (null or nested values).
+func literalType(v any) string {
+	switch v.(type) {
+	case string:
+		return "string"
+	case bool:
+		return "boolean"
+	case float64:
+		return "number"
+	default:
+		return ""
+	}
+}
+
+func makeNullable(prop any) {
+	propMap, ok := prop.(map[string]any)
+	if !ok {
+		return
+	}
+	// A $ref carries no "type" to extend with "null", so nullability is
+	// expressed as an anyOf union of the reference and null instead.
+	if ref, ok := propMap["$ref"]; ok {
+		delete(propMap, "$ref")
+		propMap["anyOf"] = []any{
+			map[string]any{"$ref": ref},
+			map[string]any{"type": "null"},
+		}
+		return
+	}
+	switch t := propMap["type"].(type) {
+	case string:
+		propMap["type"] = []any{t, "null"}
+	case []any:
+		for _, v := range t {
+			if v == "null" {
+				return
+			}
+		}
+		propMap["type"] = append(t, "null")
+	default:
+		// No "type" to extend: a typeless anyOf union (oneOf is already
+		// renamed by this point) gets a null branch, keeping the property
+		// optional instead of silently becoming required.
+		if branches, ok := propMap["anyOf"].([]any); ok {
+			for _, b := range branches {
+				if bm, ok := b.(map[string]any); ok && bm["type"] == "null" {
+					return
+				}
+			}
+			propMap["anyOf"] = append(branches, map[string]any{"type": "null"})
+		}
+	}
+}
+
+// toStringSet builds a set from a "required" field ([]string or []any).
+func toStringSet(v any) map[string]bool {
+	set := map[string]bool{}
+	switch r := v.(type) {
+	case []string:
+		for _, s := range r {
+			set[s] = true
+		}
+	case []any:
+		for _, item := range r {
+			if s, ok := item.(string); ok {
+				set[s] = true
+			}
+		}
+	}
+	return set
+}
+
+// deepCopySchema converts any schema representation into a fresh
+// map[string]any via JSON round-trip, avoiding mutation of the caller's data.
+func deepCopySchema(params any) map[string]any {
+	jsonBytes, err := json.Marshal(params)
+	if err != nil {
+		return nil
+	}
+	var m map[string]any
+	if json.Unmarshal(jsonBytes, &m) != nil {
+		return nil
+	}
+	return m
+}
+
+// lowercaseTypes recursively lowercases all "type" fields in a JSON schema map.
+func lowercaseTypes(m map[string]any) {
+	for k, v := range m {
+		if k == "type" {
+			if s, ok := v.(string); ok {
+				m[k] = strings.ToLower(s)
+			}
+		} else if vMap, ok := v.(map[string]any); ok {
+			lowercaseTypes(vMap)
+		} else if vList, ok := v.([]any); ok {
+			for _, item := range vList {
+				if itemMap, ok := item.(map[string]any); ok {
+					lowercaseTypes(itemMap)
+				}
+			}
+		}
+	}
+}
+
+// convertSchema recursively converts a genai.Schema to JSON schema format.
+// Only Type, Description, Required, Enum, Properties, and Items are carried
+// over; constraints outside this subset (Format, Minimum, Nullable, AnyOf,
+// ...) are dropped. Callers needing full fidelity should pass a raw schema
+// via ResponseJsonSchema instead, which is sent through unmodified.
+func convertSchema(schema *genai.Schema) (map[string]any, error) {
+	if schema == nil {
+		return map[string]any{"type": "object", "properties": map[string]any{}}, nil
+	}
+
+	result := make(map[string]any)
+
+	if schema.Type != genai.TypeUnspecified {
+		result["type"] = schemaTypeToString(schema.Type)
+	}
+	if schema.Description != "" {
+		result["description"] = schema.Description
+	}
+	if len(schema.Required) > 0 {
+		result["required"] = schema.Required
+	}
+	if len(schema.Enum) > 0 {
+		result["enum"] = schema.Enum
+	}
+
+	if len(schema.Properties) > 0 {
+		props := make(map[string]any)
+		for name, propSchema := range schema.Properties {
+			converted, err := convertSchema(propSchema)
+			if err != nil {
+				return nil, err
+			}
+			props[name] = converted
+		}
+		result["properties"] = props
+	}
+
+	if schema.Items != nil {
+		items, err := convertSchema(schema.Items)
+		if err != nil {
+			return nil, err
+		}
+		result["items"] = items
+	}
+
+	return result, nil
+}
+
+// schemaTypeToString converts genai.Type to JSON schema type string.
+func schemaTypeToString(t genai.Type) string {
+	types := map[genai.Type]string{
+		genai.TypeString:  "string",
+		genai.TypeNumber:  "number",
+		genai.TypeInteger: "integer",
+		genai.TypeBoolean: "boolean",
+		genai.TypeArray:   "array",
+		genai.TypeObject:  "object",
+	}
+	if s, ok := types[t]; ok {
+		return s
+	}
+	return "string"
+}
+
+// extractText extracts all text parts from a Content and joins them.
+func extractText(content *genai.Content) string {
+	if content == nil {
+		return ""
+	}
+	var texts []string
+	for _, part := range content.Parts {
+		if part.Text != "" {
+			texts = append(texts, part.Text)
+		}
+	}
+	return joinTexts(texts)
+}
+
+// joinTexts joins multiple text strings with newlines.
+func joinTexts(texts []string) string {
+	return strings.Join(texts, "\n")
+}
+
+// joinSortedKeys renders a set of item types as a stable comma-separated
+// list for error messages.
+func joinSortedKeys(set map[string]bool) string {
+	keys := slices.Sorted(maps.Keys(set))
+	return strings.Join(keys, ", ")
+}
+
+// parseJSONArgs parses a function-call arguments string into a map. Malformed
+// JSON is an error, not an empty map: a tool with side effects must not run
+// with silently emptied arguments. A literal "null" is well-formed JSON some
+// gateways emit for parameterless calls; like the empty string it means no
+// arguments.
+func parseJSONArgs(argsJSON string) (map[string]any, error) {
+	if argsJSON == "" {
+		return make(map[string]any), nil
+	}
+	var args map[string]any
+	if err := json.Unmarshal([]byte(argsJSON), &args); err != nil {
+		return nil, fmt.Errorf("malformed function call arguments %q: %w", argsJSON, err)
+	}
+	if args == nil {
+		return make(map[string]any), nil
+	}
+	return args, nil
+}

--- a/genai/openai/responses/responses.go
+++ b/genai/openai/responses/responses.go
@@ -67,6 +67,9 @@ var (
 	// skipped (unknown item types, or known items carrying no content), so
 	// converting it would produce an empty completed turn.
 	ErrNoConsumableOutput = errors.New("no consumable output items in OpenAI Responses API response")
+	// ErrFunctionCallArgs reports function call arguments that do not decode
+	// into a JSON object.
+	ErrFunctionCallArgs = errors.New("undecodable function call arguments in OpenAI Responses API response")
 )
 
 // Model implements model.LLM using the OpenAI Responses API.
@@ -268,7 +271,7 @@ func (m *Model) generateStream(ctx context.Context, req *model.LLMRequest) iter.
 				// final event includes them: losing a tool call would
 				// silently break the agent loop.
 				if event.Item.Type == "function_call" {
-					args, err := parseJSONArgs(event.Item.Arguments.OfString)
+					args, err := functionCallArgs(event.Item)
 					if err != nil {
 						yield(nil, err)
 						return
@@ -1119,7 +1122,7 @@ func convertResponse(resp *responses.Response, origin string) (*model.LLMRespons
 			}
 
 		case "function_call":
-			args, err := parseJSONArgs(item.Arguments.OfString)
+			args, err := functionCallArgs(item)
 			if err != nil {
 				return nil, err
 			}
@@ -2137,6 +2140,37 @@ func joinTexts(texts []string) string {
 func joinSortedKeys(set map[string]bool) string {
 	keys := slices.Sorted(maps.Keys(set))
 	return strings.Join(keys, ", ")
+}
+
+// functionCallArgs decodes a function call item's arguments, which arrive
+// either as a JSON string (the OpenAI form) or as a bare JSON object (some
+// OpenAI-compatible gateways). Reading only the string arm would silently
+// drop the object form's arguments.
+func functionCallArgs(item responses.ResponseOutputItemUnion) (map[string]any, error) {
+	raw := item.Arguments.OfString
+	switch v := item.Arguments.OfResponseToolSearchCallArguments.(type) {
+	case nil, string:
+		// String arm, or no arguments at all: OfString holds the payload.
+	default:
+		// Bare arm: decode from the wire bytes, so the SDK's first-key-wins
+		// union decode cannot disagree with the last-key-wins semantics of
+		// the unmarshal below.
+		raw = item.Arguments.JSON.OfResponseToolSearchCallArguments.Raw()
+		if raw == "" {
+			// A hand-built value has no wire bytes for a re-encode to
+			// disagree with.
+			b, err := json.Marshal(v)
+			if err != nil {
+				return nil, fmt.Errorf("%w (name %q, call_id %q): %w", ErrFunctionCallArgs, item.Name, item.CallID, err)
+			}
+			raw = string(b)
+		}
+	}
+	args, err := parseJSONArgs(raw)
+	if err != nil {
+		return nil, fmt.Errorf("%w (name %q, call_id %q): %w", ErrFunctionCallArgs, item.Name, item.CallID, err)
+	}
+	return args, nil
 }
 
 // parseJSONArgs parses a function-call arguments string into a map. Malformed

--- a/genai/openai/responses/responses.go
+++ b/genai/openai/responses/responses.go
@@ -249,7 +249,12 @@ func (m *Model) generateStream(ctx context.Context, req *model.LLMRequest) iter.
 					return
 				}
 
-			case "response.reasoning_summary_text.delta":
+			// OpenAI streams reasoning as summary deltas; gateways that
+			// convert other providers (e.g. new-api in front of Qwen or
+			// DeepSeek) stream the reasoning text channel instead. Either
+			// way it is the turn's thinking, so both feed the same parts.
+			case "response.reasoning_summary_text.delta",
+				"response.reasoning_text.delta":
 				if event.Delta == "" {
 					continue
 				}
@@ -1080,6 +1085,16 @@ func convertResponse(resp *responses.Response, origin string) (*model.LLMRespons
 			for _, summary := range item.Summary {
 				if summary.Text != "" {
 					summaryTexts = append(summaryTexts, summary.Text)
+				}
+			}
+			// Gateways converting other providers may fill the reasoning
+			// content field instead of the summary; without this fallback
+			// their thinking would be dropped from the final content.
+			if len(summaryTexts) == 0 {
+				for _, rc := range item.Content {
+					if rc.Text != "" {
+						summaryTexts = append(summaryTexts, rc.Text)
+					}
 				}
 			}
 			if len(summaryTexts) == 0 && item.EncryptedContent == "" {

--- a/genai/openai/responses/responses.go
+++ b/genai/openai/responses/responses.go
@@ -341,10 +341,14 @@ func (m *Model) generateStream(ctx context.Context, req *model.LLMRequest) iter.
 		// The stream ended without any terminal event (some gateways just close
 		// the connection after the last delta). Synthesize the final event from
 		// what was accumulated so the turn is persisted and ADK does not raise
-		// "last event is not final".
+		// "last event is not final". A stream that closed without delivering
+		// anything at all is an error, not a silent zero-event iteration:
+		// overloaded gateways answer 200 with an empty SSE body.
 		if acc.hasContent() || len(acc.items) > 0 {
 			shadow := responses.Response{Status: responses.ResponseStatusCompleted}
 			yield(acc.fallbackResponse(&shadow, m.origin), nil)
+		} else {
+			yield(nil, ErrNoConsumableOutput)
 		}
 	}
 }
@@ -718,6 +722,25 @@ func applyGenerationConfig(params *responses.ResponseNewParams, cfg *genai.Gener
 					},
 				}
 			} else {
+				// A multi-name allowlist is enforced by sending only the
+				// allowed function definitions: tool_choice "required" alone
+				// would leave every declared tool callable, and the native
+				// allowed_tools choice is not implemented across
+				// OpenAI-compatible backends (vLLM rejects everything but
+				// "auto" on this endpoint).
+				if len(fcc.AllowedFunctionNames) > 1 {
+					allowed := make(map[string]bool, len(fcc.AllowedFunctionNames))
+					for _, name := range fcc.AllowedFunctionNames {
+						allowed[name] = true
+					}
+					kept := make([]responses.ToolUnionParam, 0, len(fcc.AllowedFunctionNames))
+					for _, tool := range params.Tools {
+						if tool.OfFunction != nil && allowed[tool.OfFunction.Name] {
+							kept = append(kept, tool)
+						}
+					}
+					params.Tools = kept
+				}
 				params.ToolChoice = responses.ResponseNewParamsToolChoiceUnion{
 					OfToolChoiceMode: param.NewOpt(responses.ToolChoiceOptionsRequired),
 				}
@@ -807,15 +830,17 @@ func convertContentToInputItems(content *genai.Content, origin string, dangling 
 			return
 		}
 
-		// Model output with a message ID or phase builds an OutputMessage
-		// manually, so the item identity survives the stateless round trip
-		// (models like gpt-5.3-codex expect phase back on every assistant
-		// message, and the API asks for output items to be replayed as-is).
-		// Output message content can only carry text and refusals, so a
-		// message that also holds media (possible in histories written by
-		// other adapters) keeps the media and gives up the identity via the
+		// Model output with a message ID builds an OutputMessage manually,
+		// so the item identity survives the stateless round trip (models
+		// like gpt-5.3-codex expect phase back on every assistant message,
+		// and the API asks for output items to be replayed as-is). The ID is
+		// the gate: OutputMessage requires one, so phase-only content (seen
+		// in histories written by other adapters) goes through the input
+		// message path, which carries phase itself. Output message content
+		// can only carry text and refusals, so a message that also holds
+		// media keeps the media and gives up the identity via the
 		// content-list path instead of silently dropping parts.
-		if role == responses.EasyInputMessageRoleAssistant && (messageID != "" || phase != "") &&
+		if role == responses.EasyInputMessageRoleAssistant && messageID != "" &&
 			len(mediaParts) == 0 {
 			var contentParts []responses.ResponseOutputMessageContentUnionParam
 			for i, t := range textParts {
@@ -845,9 +870,16 @@ func convertContentToInputItems(content *genai.Content, origin string, dangling 
 		} else if len(mediaParts) == 0 {
 			// Type is set explicitly: the OpenAPI spec discriminates input
 			// union items on it, even though the endpoint tolerates its
-			// absence.
+			// absence. Phase is assistant-only: multi-agent histories
+			// relabel other agents' output as user while keeping part
+			// metadata, and the API rejects phase on user messages.
+			msgPhase := responses.EasyInputMessagePhase("")
+			if role == responses.EasyInputMessageRoleAssistant {
+				msgPhase = responses.EasyInputMessagePhase(phase)
+			}
 			items = append(items, responses.ResponseInputItemUnionParam{
 				OfMessage: &responses.EasyInputMessageParam{
+					Phase: msgPhase,
 					Content: responses.EasyInputMessageContentUnionParam{
 						OfString: param.NewOpt(joinTexts(textParts)),
 					},
@@ -1912,6 +1944,34 @@ func makeNullable(prop any) {
 			map[string]any{"type": "null"},
 		}
 		return
+	}
+	// A const admits exactly one value, so widening "type" alone would
+	// leave null failing the const check; the property becomes an anyOf
+	// union of the const and null instead.
+	if c, ok := propMap["const"]; ok {
+		branch := map[string]any{"const": c}
+		if t, ok := propMap["type"]; ok {
+			branch["type"] = t
+		}
+		delete(propMap, "const")
+		delete(propMap, "type")
+		propMap["anyOf"] = []any{branch, map[string]any{"type": "null"}}
+		return
+	}
+	// An enum constrains the value independently of "type", so null must
+	// join the allowed values too or the property stays effectively
+	// required.
+	if values, ok := propMap["enum"].([]any); ok {
+		hasNull := false
+		for _, v := range values {
+			if v == nil {
+				hasNull = true
+				break
+			}
+		}
+		if !hasNull {
+			propMap["enum"] = append(values, nil)
+		}
 	}
 	switch t := propMap["type"].(type) {
 	case string:

--- a/genai/openai/responses/responses.go
+++ b/genai/openai/responses/responses.go
@@ -1,20 +1,6 @@
 // SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
 // SPDX-License-Identifier: Apache-2.0
 
-// Copyright 2025 achetronic
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 // Package responses provides an OpenAI Responses API (/v1/responses)
 // implementation for the ADK.
 //
@@ -616,7 +602,9 @@ func (m *Model) buildResponseParams(req *model.LLMRequest) (responses.ResponseNe
 	return params, nil
 }
 
-// applyGenerationConfig applies optional generation settings to the request params.
+// applyGenerationConfig applies optional generation settings to the request
+// params. StopSequences is ignored: the Responses API has no stop parameter,
+// so unlike the Chat Completions adapter there is nothing to map it to.
 func applyGenerationConfig(params *responses.ResponseNewParams, cfg *genai.GenerateContentConfig) error {
 	if cfg.Temperature != nil {
 		params.Temperature = param.NewOpt(float64(*cfg.Temperature))
@@ -927,23 +915,12 @@ func convertContentToInputItems(content *genai.Content, origin string, dangling 
 			))
 
 		case part.Thought:
-			// Reasoning items carrying encrypted content are replayed so the
-			// model keeps its chain of thought across turns; reasoning models
-			// require the reasoning item preceding a function_call to be
-			// present in the input. Skipped instead of replayed when:
-			//   - the content is not an assistant turn: in multi-agent
-			//     histories another agent's output (thoughts included) shows
-			//     up under other roles, where a reasoning item is invalid;
-			//   - there is no encrypted content (e.g. gateways that ignore
-			//     the include parameter): bare IDs only resolve in the
-			//     originating response and replaying them is a 400;
-			//   - the origin does not match: encrypted content is bound to
-			//     the provider/API key/model that produced it, and replaying
-			//     it elsewhere is a 400 invalid_encrypted_content;
-			//   - no item from the same turn follows: the API rejects
-			//     dangling reasoning items.
-			// Skipping degrades gracefully: the model re-derives its
-			// reasoning for the turn instead of the request failing.
+			// Reasoning items with encrypted content are replayed so the
+			// model keeps its chain of thought across turns, as reasoning
+			// models require. Items the API would reject are skipped instead
+			// (non-assistant turns, missing encrypted content, a foreign
+			// origin, no same-turn item following), so the model re-derives
+			// its reasoning rather than the request failing with a 400.
 			if role != responses.EasyInputMessageRoleAssistant {
 				continue
 			}

--- a/genai/openai/responses/stream_aggregate_test.go
+++ b/genai/openai/responses/stream_aggregate_test.go
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
+// Copyright 2025 achetronic
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package responses
+
+import (
+	"testing"
+
+	"google.golang.org/adk/v2/model"
+	"google.golang.org/genai"
+)
+
+// TestStreamAccumulatorFinalResponse verifies that the accumulated deltas can be
+// rebuilt into a single non-partial, TurnComplete final response, with the
+// reasoning part ordered before the answer part. This is the core of the fix:
+// when the terminal event omits the aggregated output, the accumulated deltas
+// are used to produce the event ADK persists.
+func TestStreamAccumulatorFinalResponse(t *testing.T) {
+	var acc streamAccumulator
+	acc.reasoning.WriteString("think first, ")
+	acc.reasoning.WriteString("then answer.")
+	acc.addText("", 0, "hello ")
+	acc.addText("", 0, "world")
+
+	resp := acc.finalResponse(genai.FinishReasonStop, nil)
+
+	if resp.Partial {
+		t.Errorf("Partial = true, want false (only non-partial events are persisted by ADK)")
+	}
+	if !resp.TurnComplete {
+		t.Errorf("TurnComplete = false, want true")
+	}
+	if resp.FinishReason != genai.FinishReasonStop {
+		t.Errorf("FinishReason = %v, want Stop", resp.FinishReason)
+	}
+	if got := len(resp.Content.Parts); got != 2 {
+		t.Fatalf("len(Parts) = %d, want 2 (reasoning + answer)", got)
+	}
+	if p := resp.Content.Parts[0]; !p.Thought || p.Text != "think first, then answer." {
+		t.Errorf("Parts[0] = %+v, want reasoning part {Thought:true, Text:\"think first, then answer.\"}", p)
+	}
+	if p := resp.Content.Parts[1]; p.Thought || p.Text != "hello world" {
+		t.Errorf("Parts[1] = %+v, want answer part {Thought:false, Text:\"hello world\"}", p)
+	}
+}
+
+// TestStreamAccumulatorOnlyText verifies that with an answer but no reasoning,
+// the final response contains a single text part.
+func TestStreamAccumulatorOnlyText(t *testing.T) {
+	var acc streamAccumulator
+	acc.addText("", 0, "ok")
+
+	resp := acc.finalResponse(genai.FinishReasonStop, nil)
+	if got := len(resp.Content.Parts); got != 1 {
+		t.Fatalf("len(Parts) = %d, want 1", got)
+	}
+	if p := resp.Content.Parts[0]; p.Thought || p.Text != "ok" {
+		t.Errorf("Parts[0] = %+v, want {Thought:false, Text:\"ok\"}", p)
+	}
+}
+
+// Function calls completed during the stream must survive into the fallback
+// final response: losing a tool call would silently break the agent loop.
+func TestStreamAccumulatorFunctionCalls(t *testing.T) {
+	var acc streamAccumulator
+	acc.addText("", 0, "calling the tool")
+	acc.functionCalls = append(acc.functionCalls, &genai.FunctionCall{
+		ID:   "call-1",
+		Name: "get_weather",
+		Args: map[string]any{"city": "Madrid"},
+	})
+
+	resp := acc.finalResponse(genai.FinishReasonStop, nil)
+	if got := len(resp.Content.Parts); got != 2 {
+		t.Fatalf("len(Parts) = %d, want 2", got)
+	}
+	fc := resp.Content.Parts[1].FunctionCall
+	if fc == nil || fc.ID != "call-1" || fc.Name != "get_weather" {
+		t.Errorf("Parts[1].FunctionCall = %+v, want id=call-1 name=get_weather", fc)
+	}
+}
+
+// TestStreamAccumulatorHasContent checks hasContent for empty and non-empty
+// accumulators.
+func TestStreamAccumulatorHasContent(t *testing.T) {
+	var empty streamAccumulator
+	if empty.hasContent() {
+		t.Errorf("empty accumulator hasContent() = true, want false")
+	}
+
+	var withReasoning streamAccumulator
+	withReasoning.reasoning.WriteString("x")
+	if !withReasoning.hasContent() {
+		t.Errorf("reasoning-only accumulator hasContent() = false, want true")
+	}
+
+	var withText streamAccumulator
+	withText.addText("", 0, "x")
+	if !withText.hasContent() {
+		t.Errorf("text-only accumulator hasContent() = false, want true")
+	}
+
+	var withCall streamAccumulator
+	withCall.functionCalls = append(withCall.functionCalls, &genai.FunctionCall{Name: "f"})
+	if !withCall.hasContent() {
+		t.Errorf("call-only accumulator hasContent() = false, want true")
+	}
+}
+
+// TestHasNoContent verifies the fallback predicate: a nil response, a nil
+// Content, or empty Parts all count as "no content", in which case
+// generateStream falls back to the accumulated deltas.
+func TestHasNoContent(t *testing.T) {
+	cases := []struct {
+		name string
+		resp *model.LLMResponse
+		want bool
+	}{
+		{"nil response", nil, true},
+		{"nil Content", &model.LLMResponse{}, true},
+		{"empty Parts", &model.LLMResponse{Content: &genai.Content{Parts: []*genai.Part{}}}, true},
+		{"has text part", &model.LLMResponse{Content: &genai.Content{Parts: []*genai.Part{{Text: "hi"}}}}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := hasNoContent(c.resp); got != c.want {
+				t.Errorf("hasNoContent() = %v, want %v", got, c.want)
+			}
+		})
+	}
+}

--- a/genai/openai/responses/stream_aggregate_test.go
+++ b/genai/openai/responses/stream_aggregate_test.go
@@ -1,14 +1,6 @@
 // SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
 // SPDX-License-Identifier: Apache-2.0
 
-// Copyright 2025 achetronic
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-
 package responses
 
 import (

--- a/genai/openai/responses/tools_test.go
+++ b/genai/openai/responses/tools_test.go
@@ -1,14 +1,6 @@
 // SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
 // SPDX-License-Identifier: Apache-2.0
 
-// Copyright 2025 achetronic
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-
 package responses
 
 import (

--- a/genai/openai/responses/tools_test.go
+++ b/genai/openai/responses/tools_test.go
@@ -1,0 +1,297 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
+// Copyright 2025 achetronic
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package responses
+
+import (
+	"testing"
+
+	"google.golang.org/genai"
+)
+
+// convertTools maps genai FunctionDeclarations into Responses API
+// FunctionToolParam entries. Nil tools are skipped. ParametersJsonSchema
+// takes precedence over the legacy Parameters field.
+func TestConvertTools(t *testing.T) {
+	t.Run("single function declaration", func(t *testing.T) {
+		tools := []*genai.Tool{{
+			FunctionDeclarations: []*genai.FunctionDeclaration{{
+				Name:        "get_weather",
+				Description: "Get weather for a city",
+				ParametersJsonSchema: map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"city": map[string]any{"type": "string"},
+					},
+				},
+			}},
+		}}
+
+		got, err := convertTools(tools)
+		if err != nil {
+			t.Fatalf("convertTools: %v", err)
+		}
+		if len(got) != 1 {
+			t.Fatalf("expected 1 tool, got %d", len(got))
+		}
+		fn := got[0].OfFunction
+		if fn == nil {
+			t.Fatalf("expected OfFunction to be set")
+		}
+		if fn.Name != "get_weather" {
+			t.Errorf("Name = %q, want get_weather", fn.Name)
+		}
+	})
+
+	t.Run("nil tool is skipped", func(t *testing.T) {
+		tools := []*genai.Tool{nil, {
+			FunctionDeclarations: []*genai.FunctionDeclaration{{
+				Name: "fn",
+			}},
+		}}
+
+		got, err := convertTools(tools)
+		if err != nil {
+			t.Fatalf("convertTools: %v", err)
+		}
+		if len(got) != 1 {
+			t.Fatalf("expected 1 tool (nil skipped), got %d", len(got))
+		}
+	})
+
+	t.Run("multiple declarations across tool groups", func(t *testing.T) {
+		tools := []*genai.Tool{
+			{FunctionDeclarations: []*genai.FunctionDeclaration{
+				{Name: "a"}, {Name: "b"},
+			}},
+			{FunctionDeclarations: []*genai.FunctionDeclaration{
+				{Name: "c"},
+			}},
+		}
+
+		got, err := convertTools(tools)
+		if err != nil {
+			t.Fatalf("convertTools: %v", err)
+		}
+		if len(got) != 3 {
+			t.Fatalf("expected 3 tools, got %d", len(got))
+		}
+	})
+}
+
+// convertInlineDataToPart routes different MIME types to the correct
+// Responses API content part. Images use ResponseInputImageParam; documents
+// use ResponseInputFileParam. Audio must error: the API's file inputs do not
+// accept it.
+func TestConvertInlineDataToPart(t *testing.T) {
+	cases := []struct {
+		name     string
+		blob     *genai.Blob
+		wantType string // "image", "file", "error"
+	}{
+		{"png image", &genai.Blob{MIMEType: "image/png", Data: []byte("x")}, "image"},
+		{"jpeg image", &genai.Blob{MIMEType: "image/jpeg", Data: []byte("x")}, "image"},
+		{"webp image", &genai.Blob{MIMEType: "image/webp", Data: []byte("x")}, "image"},
+		{"gif image", &genai.Blob{MIMEType: "image/gif", Data: []byte("x")}, "image"},
+		{"pdf file", &genai.Blob{MIMEType: "application/pdf", Data: []byte("x")}, "file"},
+		{"text file", &genai.Blob{MIMEType: "text/plain", Data: []byte("x")}, "file"},
+		{"json file", &genai.Blob{MIMEType: "application/json", Data: []byte("x")}, "file"},
+		{"audio rejected", &genai.Blob{MIMEType: "audio/wav", Data: []byte("x")}, "error"},
+		{"unsupported", &genai.Blob{MIMEType: "video/mp4", Data: []byte("x")}, "error"},
+		{"nil blob", nil, "error"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := convertInlineDataToPart(c.blob)
+
+			if c.wantType == "error" {
+				if err == nil {
+					t.Errorf("expected error, got %+v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			switch c.wantType {
+			case "image":
+				if got.OfInputImage == nil {
+					t.Errorf("expected OfInputImage, got %+v", got)
+				}
+			case "file":
+				if got.OfInputFile == nil {
+					t.Errorf("expected OfInputFile, got %+v", got)
+				}
+			}
+		})
+	}
+}
+
+// convertFileDataToPart passes a remote image URL straight through to
+// ResponseInputImageParam and a remote PDF to ResponseInputFileParam's
+// file_url. The URI must be http(s); plain http is allowed for
+// API-compatible gateways. Everything else (and a nil input) must return an
+// error instead of being silently dropped.
+func TestConvertFileDataToPart(t *testing.T) {
+	const fileURI = "https://cdn.example.com/cat.png"
+
+	cases := []struct {
+		name     string
+		data     *genai.FileData
+		wantType string // "image", "file", "error"
+	}{
+		{"png image", &genai.FileData{MIMEType: "image/png", FileURI: fileURI}, "image"},
+		{"jpeg image", &genai.FileData{MIMEType: "image/jpeg", FileURI: fileURI}, "image"},
+		{"webp image", &genai.FileData{MIMEType: "image/webp", FileURI: fileURI}, "image"},
+		{"plain http allowed for gateways", &genai.FileData{MIMEType: "image/png", FileURI: "http://localhost:8080/cat.png"}, "image"},
+		{"MIME parameters stripped", &genai.FileData{MIMEType: "image/png; charset=utf-8", FileURI: fileURI}, "image"},
+		{"pdf becomes input_file", &genai.FileData{MIMEType: "application/pdf", FileURI: "https://cdn.example.com/report.pdf"}, "file"},
+		{"docx becomes input_file", &genai.FileData{MIMEType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document", FileURI: "https://cdn.example.com/spec.docx"}, "file"},
+		{"csv becomes input_file", &genai.FileData{MIMEType: "text/csv", FileURI: "https://cdn.example.com/data.csv"}, "file"},
+		{"application/csv becomes input_file", &genai.FileData{MIMEType: "application/csv", FileURI: "https://cdn.example.com/data.csv"}, "file"},
+		{"javascript becomes input_file", &genai.FileData{MIMEType: "application/javascript", FileURI: "https://cdn.example.com/app.js"}, "file"},
+		{"rfc822 mail becomes input_file", &genai.FileData{MIMEType: "message/rfc822", FileURI: "https://cdn.example.com/mail.eml"}, "file"},
+		{"google doc becomes input_file", &genai.FileData{MIMEType: "application/vnd.google-apps.document", FileURI: "https://cdn.example.com/doc"}, "file"},
+		{"typescript becomes input_file", &genai.FileData{MIMEType: "application/typescript", FileURI: "https://cdn.example.com/app.ts"}, "file"},
+		{"yaml becomes input_file", &genai.FileData{MIMEType: "application/yaml", FileURI: "https://cdn.example.com/conf.yaml"}, "file"},
+		{"x-toml becomes input_file", &genai.FileData{MIMEType: "application/x-toml", FileURI: "https://cdn.example.com/conf.toml"}, "file"},
+		{"sql becomes input_file", &genai.FileData{MIMEType: "application/x-sql", FileURI: "https://cdn.example.com/schema.sql"}, "file"},
+		{"audio URL rejected", &genai.FileData{MIMEType: "audio/mpeg", FileURI: "https://cdn.example.com/talk.mp3"}, "error"},
+		{"unsupported", &genai.FileData{MIMEType: "video/mp4", FileURI: fileURI}, "error"},
+		{"empty MIME type rejected", &genai.FileData{MIMEType: "", FileURI: fileURI}, "error"},
+		{"gs scheme rejected", &genai.FileData{MIMEType: "image/png", FileURI: "gs://bucket/cat.png"}, "error"},
+		{"data URI rejected (use InlineData)", &genai.FileData{MIMEType: "image/png", FileURI: "data:image/png;base64,AAAA"}, "error"},
+		{"empty URI rejected", &genai.FileData{MIMEType: "image/png", FileURI: ""}, "error"},
+		{"nil file data", nil, "error"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := convertFileDataToPart(c.data)
+
+			if c.wantType == "error" {
+				if err == nil {
+					t.Errorf("expected error, got %+v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if c.wantType == "file" {
+				if got.OfInputFile == nil {
+					t.Fatalf("expected OfInputFile, got %+v", got)
+				}
+				if url := got.OfInputFile.FileURL.Value; url != c.data.FileURI {
+					t.Errorf("FileURL = %q, want the raw file URI %q", url, c.data.FileURI)
+				}
+				return
+			}
+			if got.OfInputImage == nil {
+				t.Fatalf("expected OfInputImage, got %+v", got)
+			}
+			if url := got.OfInputImage.ImageURL.Value; url != c.data.FileURI {
+				t.Errorf("ImageURL = %q, want the raw file URI %q", url, c.data.FileURI)
+			}
+		})
+	}
+}
+
+// Tool parameters that cannot be serialized to JSON must fail loudly:
+// silently sending the request without the tool definition surfaces as
+// inexplicable model behaviour.
+func TestConvertTools_UnserializableParams(t *testing.T) {
+	tools := []*genai.Tool{{
+		FunctionDeclarations: []*genai.FunctionDeclaration{{
+			Name:                 "broken",
+			ParametersJsonSchema: make(chan int),
+		}},
+	}}
+
+	if _, err := convertTools(tools); err == nil {
+		t.Fatalf("convertTools() error = nil, want serialization error")
+	}
+}
+
+// Tool facets without a Responses API mapping must error instead of
+// silently producing an empty tool list.
+func TestConvertTools_UnsupportedFacetsError(t *testing.T) {
+	_, err := convertTools([]*genai.Tool{{GoogleSearch: &genai.GoogleSearch{}}})
+	if err == nil {
+		t.Fatalf("expected an error for a GoogleSearch tool, got none")
+	}
+}
+
+// Base64 documents must carry a filename with an extension: the API
+// identifies the document type by it. DisplayName wins; a missing extension
+// is filled in from the MIME type, and types with no unambiguous extension
+// require the caller to name the file.
+func TestConvertInlineDataToPart_DocumentFilename(t *testing.T) {
+	cases := []struct {
+		name string
+		blob *genai.Blob
+		want string // expected filename, "" means an error is expected
+	}{
+		{"MIME-derived default", &genai.Blob{MIMEType: "application/pdf", Data: []byte("x")}, "input.pdf"},
+		{"DisplayName with extension kept", &genai.Blob{MIMEType: "text/csv", Data: []byte("x"), DisplayName: "report.csv"}, "report.csv"},
+		{"DisplayName without extension gains one", &genai.Blob{MIMEType: "application/pdf", Data: []byte("x"), DisplayName: "季度报告"}, "季度报告.pdf"},
+		{"python maps to py", &genai.Blob{MIMEType: "text/x-python", Data: []byte("x")}, "input.py"},
+		{"ambiguous iwork requires DisplayName", &genai.Blob{MIMEType: "application/vnd.apple.iwork", Data: []byte("x")}, ""},
+		{"ambiguous iwork with DisplayName passes", &genai.Blob{MIMEType: "application/vnd.apple.iwork", Data: []byte("x"), DisplayName: "deck.key"}, "deck.key"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := convertInlineDataToPart(c.blob)
+			if c.want == "" {
+				if err == nil {
+					t.Fatalf("expected an error, got %+v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if fn := got.OfInputFile.Filename.Value; fn != c.want {
+				t.Errorf("Filename = %q, want %q", fn, c.want)
+			}
+		})
+	}
+}
+
+// extensionForMIME maps explicit cases, falls back to the stripped subtype,
+// and returns empty for residues that are not usable extensions.
+func TestExtensionForMIME(t *testing.T) {
+	cases := map[string]string{
+		"text/plain": "txt",
+		"application/vnd.openxmlformats-officedocument.wordprocessingml.document": "docx",
+		"application/x-sql":                    "sql",
+		"application/json":                     "json",
+		"text/csv":                             "csv",
+		"application/x-yaml":                   "yaml",
+		"message/rfc822":                       "eml",
+		"text/x-python":                        "py",
+		"text/x-typescript":                    "ts",
+		"application/x-rust":                   "rs",
+		"application/x-bash":                   "sh",
+		"text/x-c++":                           "cpp",
+		"text/x-golang":                        "go",
+		"application/vnd.apple.iwork":          "",
+		"application/vnd.google-apps.document": "",
+	}
+	for mime, want := range cases {
+		if got := extensionForMIME(mime); got != want {
+			t.Errorf("extensionForMIME(%q) = %q, want %q", mime, got, want)
+		}
+	}
+}

--- a/genai/openai/responses/utils_test.go
+++ b/genai/openai/responses/utils_test.go
@@ -1,0 +1,194 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
+// Copyright 2025 achetronic
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package responses
+
+import (
+	"testing"
+
+	"github.com/openai/openai-go/v3/responses"
+	"github.com/openai/openai-go/v3/shared"
+	"google.golang.org/genai"
+)
+
+func TestConvertRole(t *testing.T) {
+	cases := []struct {
+		in   string
+		want responses.EasyInputMessageRole
+	}{
+		{"user", responses.EasyInputMessageRoleUser},
+		{"model", responses.EasyInputMessageRoleAssistant},
+		{"assistant", responses.EasyInputMessageRoleAssistant},
+		{"system", responses.EasyInputMessageRoleSystem},
+		{"unknown", responses.EasyInputMessageRoleUser},
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			if got := convertRole(c.in); got != c.want {
+				t.Errorf("convertRole(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestConvertStatus(t *testing.T) {
+	cases := []struct {
+		name    string
+		status  responses.ResponseStatus
+		details responses.ResponseIncompleteDetails
+		want    genai.FinishReason
+	}{
+		{"completed", responses.ResponseStatusCompleted, responses.ResponseIncompleteDetails{}, genai.FinishReasonStop},
+		{"incomplete max tokens", responses.ResponseStatusIncomplete, responses.ResponseIncompleteDetails{Reason: "max_output_tokens"}, genai.FinishReasonMaxTokens},
+		{"incomplete content filter", responses.ResponseStatusIncomplete, responses.ResponseIncompleteDetails{Reason: "content_filter"}, genai.FinishReasonSafety},
+		{"incomplete unknown reason", responses.ResponseStatusIncomplete, responses.ResponseIncompleteDetails{Reason: "other"}, genai.FinishReasonUnspecified},
+		{"failed", responses.ResponseStatusFailed, responses.ResponseIncompleteDetails{}, genai.FinishReasonUnspecified},
+		{"cancelled", responses.ResponseStatusCancelled, responses.ResponseIncompleteDetails{}, genai.FinishReasonUnspecified},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := convertStatus(c.status, c.details); got != c.want {
+				t.Errorf("convertStatus(%q) = %v, want %v", c.status, got, c.want)
+			}
+		})
+	}
+}
+
+// convertThinkingLevel maps genai's three-level enum to the Responses API
+// reasoning effort. Anything outside Low/High defaults to Medium.
+func TestConvertThinkingLevel(t *testing.T) {
+	cases := []struct {
+		level genai.ThinkingLevel
+		want  shared.ReasoningEffort
+	}{
+		{genai.ThinkingLevelMinimal, shared.ReasoningEffortMinimal},
+		{genai.ThinkingLevelLow, shared.ReasoningEffortLow},
+		{genai.ThinkingLevelHigh, shared.ReasoningEffortHigh},
+		{genai.ThinkingLevel(""), shared.ReasoningEffortMedium},
+		{genai.ThinkingLevel("invalid"), shared.ReasoningEffortMedium},
+	}
+	for _, c := range cases {
+		t.Run(string(c.level), func(t *testing.T) {
+			if got := convertThinkingLevel(c.level); got != c.want {
+				t.Errorf("convertThinkingLevel(%q) = %q, want %q", c.level, got, c.want)
+			}
+		})
+	}
+}
+
+func TestSchemaTypeToString(t *testing.T) {
+	cases := []struct {
+		in   genai.Type
+		want string
+	}{
+		{genai.TypeString, "string"},
+		{genai.TypeNumber, "number"},
+		{genai.TypeInteger, "integer"},
+		{genai.TypeBoolean, "boolean"},
+		{genai.TypeArray, "array"},
+		{genai.TypeObject, "object"},
+		{genai.TypeUnspecified, "string"},
+		{genai.Type("unknown"), "string"},
+	}
+	for _, c := range cases {
+		t.Run(c.want, func(t *testing.T) {
+			if got := schemaTypeToString(c.in); got != c.want {
+				t.Errorf("schemaTypeToString(%v) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestExtractText(t *testing.T) {
+	cases := []struct {
+		name    string
+		content *genai.Content
+		want    string
+	}{
+		{"nil content", nil, ""},
+		{"empty parts", &genai.Content{Parts: []*genai.Part{}}, ""},
+		{"single text", &genai.Content{Parts: []*genai.Part{{Text: "hello"}}}, "hello"},
+		{"multiple texts", &genai.Content{Parts: []*genai.Part{{Text: "a"}, {Text: "b"}}}, "a\nb"},
+		{"skips non-text", &genai.Content{Parts: []*genai.Part{
+			{Text: "hi"},
+			{FunctionCall: &genai.FunctionCall{Name: "fn"}},
+			{Text: "bye"},
+		}}, "hi\nbye"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := extractText(c.content); got != c.want {
+				t.Errorf("extractText() = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestJoinTexts(t *testing.T) {
+	cases := []struct {
+		in   []string
+		want string
+	}{
+		{nil, ""},
+		{[]string{"a"}, "a"},
+		{[]string{"a", "b", "c"}, "a\nb\nc"},
+	}
+	for _, c := range cases {
+		if got := joinTexts(c.in); got != c.want {
+			t.Errorf("joinTexts(%v) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// Malformed arguments must error instead of degrading to an empty map: a
+// tool with side effects must not run with silently emptied arguments.
+func TestParseJSONArgs(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		want    int // expected number of keys
+		wantErr bool
+	}{
+		{"empty string", "", 0, false},
+		{"valid object", `{"a":1,"b":2}`, 2, false},
+		{"malformed JSON", `{broken`, 0, true},
+		{"truncated JSON", `{`, 0, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := parseJSONArgs(c.in)
+			if c.wantErr {
+				if err == nil {
+					t.Fatalf("parseJSONArgs(%q) = %v, want error", c.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseJSONArgs(%q): %v", c.in, err)
+			}
+			if len(got) != c.want {
+				t.Errorf("parseJSONArgs(%q) has %d keys, want %d", c.in, len(got), c.want)
+			}
+		})
+	}
+}
+
+// A literal "null" is well-formed JSON some gateways emit for parameterless
+// calls: it means no arguments, not a malformed payload.
+func TestParseJSONArgs_NullMeansNoArguments(t *testing.T) {
+	got, err := parseJSONArgs("null")
+	if err != nil {
+		t.Fatalf("parseJSONArgs(null): %v", err)
+	}
+	if got == nil || len(got) != 0 {
+		t.Errorf("parseJSONArgs(null) = %#v, want a non-nil empty map", got)
+	}
+}

--- a/genai/openai/responses/utils_test.go
+++ b/genai/openai/responses/utils_test.go
@@ -1,14 +1,6 @@
 // SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
 // SPDX-License-Identifier: Apache-2.0
 
-// Copyright 2025 achetronic
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-
 package responses
 
 import (

--- a/genai/openai/responses/utils_test.go
+++ b/genai/openai/responses/utils_test.go
@@ -4,6 +4,9 @@
 package responses
 
 import (
+	"encoding/json"
+	"errors"
+	"reflect"
 	"testing"
 
 	"github.com/openai/openai-go/v3/responses"
@@ -182,5 +185,147 @@ func TestParseJSONArgs_NullMeansNoArguments(t *testing.T) {
 	}
 	if got == nil || len(got) != 0 {
 		t.Errorf("parseJSONArgs(null) = %#v, want a non-nil empty map", got)
+	}
+}
+
+// TestFunctionCallArgs_Decoded exercises arguments through the SDK's real
+// UnmarshalJSON path: a struct literal bypasses union decoding, so only a
+// wire payload shows which union arm a given form populates.
+func TestFunctionCallArgs_Decoded(t *testing.T) {
+	cases := []struct {
+		name    string
+		raw     string
+		want    map[string]any
+		wantErr bool
+	}{
+		{
+			name: "string arguments",
+			raw:  `{"type":"function_call","name":"f","call_id":"c","arguments":"{\"city\":\"Paris\"}"}`,
+			want: map[string]any{"city": "Paris"},
+		},
+		{
+			// Some OpenAI-compatible gateways send a bare JSON object here;
+			// those arguments must not be dropped.
+			name: "object arguments",
+			raw:  `{"type":"function_call","name":"f","call_id":"c","arguments":{"city":"Paris"}}`,
+			want: map[string]any{"city": "Paris"},
+		},
+		{
+			name: "empty object arguments",
+			raw:  `{"type":"function_call","name":"f","call_id":"c","arguments":{}}`,
+			want: map[string]any{},
+		},
+		{
+			name: "empty string arguments",
+			raw:  `{"type":"function_call","name":"f","call_id":"c","arguments":""}`,
+			want: map[string]any{},
+		},
+		{
+			name: "null arguments",
+			raw:  `{"type":"function_call","name":"f","call_id":"c","arguments":null}`,
+			want: map[string]any{},
+		},
+		{
+			name: "absent arguments",
+			raw:  `{"type":"function_call","name":"f","call_id":"c"}`,
+			want: map[string]any{},
+		},
+		{
+			name: "null string arguments",
+			raw:  `{"type":"function_call","name":"f","call_id":"c","arguments":"null"}`,
+			want: map[string]any{},
+		},
+		{
+			// The SDK's union decode keeps the first duplicate key; the raw
+			// bytes must go through the last-one-wins rule of encoding/json,
+			// matching every other arguments consumer in the package.
+			name: "duplicate keys keep the last",
+			raw:  `{"type":"function_call","name":"f","call_id":"c","arguments":{"path":"/tmp/a","path":"/tmp/b"}}`,
+			want: map[string]any{"path": "/tmp/b"},
+		},
+		{
+			name:    "array arguments",
+			raw:     `{"type":"function_call","name":"f","call_id":"c","arguments":[1,2]}`,
+			wantErr: true,
+		},
+		{
+			name:    "number arguments",
+			raw:     `{"type":"function_call","name":"f","call_id":"c","arguments":42}`,
+			wantErr: true,
+		},
+		{
+			name:    "non-object string arguments",
+			raw:     `{"type":"function_call","name":"f","call_id":"c","arguments":"[1,2]"}`,
+			wantErr: true,
+		},
+		{
+			// Overflows float64: must be rejected from the original bytes,
+			// not resurface as a re-encoding failure of the SDK's +Inf value.
+			name:    "out of range number",
+			raw:     `{"type":"function_call","name":"f","call_id":"c","arguments":{"x":1e400}}`,
+			wantErr: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var item responses.ResponseOutputItemUnion
+			if err := json.Unmarshal([]byte(c.raw), &item); err != nil {
+				t.Fatalf("unmarshal item: %v", err)
+			}
+			got, err := functionCallArgs(item)
+			if c.wantErr {
+				if !errors.Is(err, ErrFunctionCallArgs) {
+					t.Fatalf("err = %v, want ErrFunctionCallArgs", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("functionCallArgs: %v", err)
+			}
+			if got == nil {
+				t.Fatalf("Args = nil, want a non-nil map")
+			}
+			if !reflect.DeepEqual(got, c.want) {
+				t.Errorf("Args = %#v, want %#v", got, c.want)
+			}
+		})
+	}
+}
+
+// TestFunctionCallArgs_HandBuilt covers struct literals with no JSON
+// metadata behind them, the form tests and local callers build.
+func TestFunctionCallArgs_HandBuilt(t *testing.T) {
+	cases := []struct {
+		name string
+		args responses.ResponseOutputItemUnionArguments
+		want map[string]any
+	}{
+		{
+			name: "string arm",
+			args: responses.ResponseOutputItemUnionArguments{OfString: `{"city":"Paris"}`},
+			want: map[string]any{"city": "Paris"},
+		},
+		{
+			name: "bare arm",
+			args: responses.ResponseOutputItemUnionArguments{OfResponseToolSearchCallArguments: map[string]any{"city": "Paris"}},
+			want: map[string]any{"city": "Paris"},
+		},
+		{
+			name: "zero value",
+			args: responses.ResponseOutputItemUnionArguments{},
+			want: map[string]any{},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			item := responses.ResponseOutputItemUnion{Type: "function_call", Name: "f", CallID: "c", Arguments: c.args}
+			got, err := functionCallArgs(item)
+			if err != nil {
+				t.Fatalf("functionCallArgs: %v", err)
+			}
+			if !reflect.DeepEqual(got, c.want) {
+				t.Errorf("Args = %#v, want %#v", got, c.want)
+			}
+		})
 	}
 }

--- a/genai/openai/responses/wire_test.go
+++ b/genai/openai/responses/wire_test.go
@@ -1,14 +1,6 @@
 // SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
 // SPDX-License-Identifier: Apache-2.0
 
-// Copyright 2025 achetronic
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-
 package responses
 
 import (
@@ -756,5 +748,71 @@ func TestWireBody_OrphanOutputDropped(t *testing.T) {
 	item, _ := input[0].(map[string]any)
 	if item["type"] == "function_call_output" {
 		t.Errorf("input[0] = %v, want the orphan output dropped", item)
+	}
+}
+
+// Some gateways close the stream after the last delta without sending any
+// terminal event. The final turn must still be synthesized from the
+// accumulated deltas, or ADK raises "last event is not final" and the
+// assistant turn is lost from history.
+func TestWireBody_StreamNoTerminalEvent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		io.WriteString(w, "event: response.output_text.delta\n")
+		io.WriteString(w, `data: {"type":"response.output_text.delta","delta":"hel","sequence_number":1}`+"\n\n")
+		io.WriteString(w, "event: response.output_text.delta\n")
+		io.WriteString(w, `data: {"type":"response.output_text.delta","delta":"lo","sequence_number":2}`+"\n\n")
+	}))
+	defer srv.Close()
+
+	m := New(Config{BaseURL: srv.URL, APIKey: "test-key", ModelName: "gpt-test"})
+
+	var final *model.LLMResponse
+	req := &model.LLMRequest{Contents: []*genai.Content{
+		{Role: "user", Parts: []*genai.Part{{Text: "hi"}}},
+	}}
+	for resp, err := range m.GenerateContent(context.Background(), req, true) {
+		if err != nil {
+			t.Fatalf("GenerateContent: %v", err)
+		}
+		if !resp.Partial {
+			final = resp
+		}
+	}
+	if final == nil {
+		t.Fatalf("no final (non-partial) response was synthesized")
+	}
+	if got := extractText(final.Content); got != "hello" {
+		t.Errorf("final text = %q, want the accumulated deltas %q", got, "hello")
+	}
+}
+
+// Sampling settings must land on the wire: a config dropped between the ADK
+// request and the SDK params would be invisible to callers until the model
+// behaves differently. Values are float32-exact so the assertion is not at
+// the mercy of float32-to-float64 widening.
+func TestWireBody_GenerationConfig(t *testing.T) {
+	req := &model.LLMRequest{
+		Contents: []*genai.Content{
+			{Role: "user", Parts: []*genai.Part{{Text: "hi"}}},
+		},
+		Config: &genai.GenerateContentConfig{
+			Temperature:     genai.Ptr[float32](0.5),
+			TopP:            genai.Ptr[float32](0.25),
+			MaxOutputTokens: 128,
+		},
+	}
+
+	body := captureBody(t, req)
+
+	if body["temperature"] != 0.5 {
+		t.Errorf("temperature = %v, want 0.5", body["temperature"])
+	}
+	if body["top_p"] != 0.25 {
+		t.Errorf("top_p = %v, want 0.25", body["top_p"])
+	}
+	if body["max_output_tokens"] != float64(128) {
+		t.Errorf("max_output_tokens = %v, want 128", body["max_output_tokens"])
 	}
 }

--- a/genai/openai/responses/wire_test.go
+++ b/genai/openai/responses/wire_test.go
@@ -816,3 +816,114 @@ func TestWireBody_GenerationConfig(t *testing.T) {
 		t.Errorf("max_output_tokens = %v, want 128", body["max_output_tokens"])
 	}
 }
+
+// A multi-name allowlist must reach the wire as a filtered tool list plus
+// tool_choice required: "required" alone leaves every declared tool
+// callable, which defeats the allowlist.
+func TestWireBody_MultiNameAllowlistFiltersTools(t *testing.T) {
+	tool := func(name string) *genai.Tool {
+		return &genai.Tool{FunctionDeclarations: []*genai.FunctionDeclaration{{
+			Name:                 name,
+			ParametersJsonSchema: map[string]any{"type": "object"},
+		}}}
+	}
+	req := &model.LLMRequest{
+		Contents: []*genai.Content{
+			{Role: "user", Parts: []*genai.Part{{Text: "hi"}}},
+		},
+		Config: &genai.GenerateContentConfig{
+			Tools: []*genai.Tool{tool("search"), tool("delete"), tool("rename")},
+			ToolConfig: &genai.ToolConfig{FunctionCallingConfig: &genai.FunctionCallingConfig{
+				Mode:                 genai.FunctionCallingConfigModeAny,
+				AllowedFunctionNames: []string{"search", "rename"},
+			}},
+		},
+	}
+
+	body := captureBody(t, req)
+
+	if body["tool_choice"] != "required" {
+		t.Errorf("tool_choice = %v, want required", body["tool_choice"])
+	}
+	tools, _ := body["tools"].([]any)
+	if len(tools) != 2 {
+		t.Fatalf("tools on the wire = %d, want the 2 allowed: %v", len(tools), tools)
+	}
+	names := map[string]bool{}
+	for _, raw := range tools {
+		toolMap, _ := raw.(map[string]any)
+		names[toolMap["name"].(string)] = true
+	}
+	if !names["search"] || !names["rename"] || names["delete"] {
+		t.Errorf("tool names on the wire = %v, want search and rename only", names)
+	}
+}
+
+// Assistant history carrying a phase but no message ID must replay as a
+// plain input message with the phase kept: OutputMessage requires an id,
+// so building one with an empty id is a request the API rejects.
+func TestWireBody_PhaseOnlyReplaysAsInputMessage(t *testing.T) {
+	req := &model.LLMRequest{
+		Contents: []*genai.Content{
+			{Role: "user", Parts: []*genai.Part{{Text: "hi"}}},
+			{Role: "model", Parts: []*genai.Part{{
+				Text:         "thinking out loud",
+				PartMetadata: map[string]any{"phase": "commentary"},
+			}}},
+		},
+	}
+
+	body := captureBody(t, req)
+
+	input, _ := body["input"].([]any)
+	if len(input) != 2 {
+		t.Fatalf("input items = %d, want 2: %v", len(input), input)
+	}
+	msg, _ := input[1].(map[string]any)
+	if msg["type"] != "message" || msg["role"] != "assistant" {
+		t.Fatalf("input[1] = %v, want an assistant message", msg)
+	}
+	if _, hasID := msg["id"]; hasID {
+		t.Errorf("input[1] = %v, want no id field (OutputMessage requires a real one)", msg)
+	}
+	if _, isString := msg["content"].(string); !isString {
+		t.Errorf("content = %v, want the plain input message string form", msg["content"])
+	}
+	if msg["phase"] != "commentary" {
+		t.Errorf("phase = %v, want commentary kept on the input message", msg["phase"])
+	}
+}
+
+// A stream that answers 200 and closes without delivering any event must
+// surface an error instead of ending as a silent zero-event iteration:
+// overloaded gateways answer exactly this shape.
+func TestWireBody_StreamEmptyIsAnError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "text/event-stream")
+	}))
+	defer srv.Close()
+
+	m := New(Config{BaseURL: srv.URL, APIKey: "test-key", ModelName: "gpt-test"})
+
+	req := &model.LLMRequest{Contents: []*genai.Content{
+		{Role: "user", Parts: []*genai.Part{{Text: "hi"}}},
+	}}
+	var streamErr error
+	var responseCount int
+	for resp, err := range m.GenerateContent(context.Background(), req, true) {
+		if err != nil {
+			streamErr = err
+			break
+		}
+		if resp != nil {
+			responseCount++
+		}
+	}
+	if responseCount != 0 {
+		t.Errorf("responses yielded = %d, want none from an empty stream", responseCount)
+	}
+	if !errors.Is(streamErr, ErrNoConsumableOutput) {
+		t.Errorf("err = %v, want ErrNoConsumableOutput", streamErr)
+	}
+}

--- a/genai/openai/responses/wire_test.go
+++ b/genai/openai/responses/wire_test.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 
 	"google.golang.org/adk/v2/model"
@@ -247,6 +248,51 @@ func TestWireBody_StreamMalformedTerminalArguments(t *testing.T) {
 	}
 	if gotErr == nil {
 		t.Fatalf("expected an error for malformed terminal arguments, got none")
+	}
+}
+
+// A gateway that streams function_call items with object-form arguments must
+// deliver those arguments in the final response; reading only the string
+// union arm would yield the call with an empty argument map.
+func TestWireBody_StreamObjectArguments(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		io.WriteString(w, "event: response.output_item.done\n")
+		io.WriteString(w, `data: {"type":"response.output_item.done","sequence_number":1,"output_index":0,"item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"search","arguments":{"q":"weather"}}}`+"\n\n")
+		io.WriteString(w, "event: response.completed\n")
+		io.WriteString(w, `data: {"type":"response.completed","sequence_number":2,"response":{"id":"resp_1","status":"completed","output":[{"type":"function_call","id":"fc_1","call_id":"call_1","name":"search","arguments":{"q":"weather"}}],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2,"input_tokens_details":{"cached_tokens":0},"output_tokens_details":{"reasoning_tokens":0}}}}`+"\n\n")
+	}))
+	defer srv.Close()
+
+	m := New(Config{BaseURL: srv.URL, APIKey: "test-key", ModelName: "gpt-test"})
+
+	req := &model.LLMRequest{Contents: []*genai.Content{
+		{Role: "user", Parts: []*genai.Part{{Text: "hi"}}},
+	}}
+	var final *model.LLMResponse
+	for resp, err := range m.GenerateContent(context.Background(), req, true) {
+		if err != nil {
+			t.Fatalf("GenerateContent: %v", err)
+		}
+		if resp != nil && !resp.Partial {
+			final = resp
+		}
+	}
+	if final == nil {
+		t.Fatalf("no final response yielded")
+	}
+	var fc *genai.FunctionCall
+	for _, p := range final.Content.Parts {
+		if p.FunctionCall != nil {
+			fc = p.FunctionCall
+		}
+	}
+	if fc == nil {
+		t.Fatalf("no FunctionCall in final response: %#v", final.Content)
+	}
+	if want := map[string]any{"q": "weather"}; !reflect.DeepEqual(fc.Args, want) {
+		t.Errorf("Args = %#v, want %#v", fc.Args, want)
 	}
 }
 

--- a/genai/openai/responses/wire_test.go
+++ b/genai/openai/responses/wire_test.go
@@ -689,6 +689,60 @@ func TestWireBody_StreamFallbackPrependsDeltaReasoning(t *testing.T) {
 	}
 }
 
+// Gateways converting other providers stream reasoning on the text channel
+// (response.reasoning_text.delta) rather than the summary channel OpenAI
+// uses. The deltas must yield live thought parts and feed the fallback
+// accumulator, or such backends show no thinking at all.
+func TestWireBody_StreamReasoningTextDeltas(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		io.WriteString(w, "event: response.reasoning_text.delta\n")
+		io.WriteString(w, `data: {"type":"response.reasoning_text.delta","delta":"compare the ","sequence_number":1}`+"\n\n")
+		io.WriteString(w, "event: response.reasoning_text.delta\n")
+		io.WriteString(w, `data: {"type":"response.reasoning_text.delta","delta":"decimals","sequence_number":2}`+"\n\n")
+		io.WriteString(w, "event: response.output_item.done\n")
+		io.WriteString(w, `data: {"type":"response.output_item.done","sequence_number":3,"output_index":1,"item":{"type":"message","id":"msg_1","role":"assistant","status":"completed","content":[{"type":"output_text","text":"9.9 is larger"}]}}`+"\n\n")
+		io.WriteString(w, "event: response.completed\n")
+		io.WriteString(w, `data: {"type":"response.completed","sequence_number":4,"response":{"id":"resp_1","status":"completed","output":[],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2,"input_tokens_details":{"cached_tokens":0},"output_tokens_details":{"reasoning_tokens":0}}}}`+"\n\n")
+	}))
+	defer srv.Close()
+
+	m := New(Config{BaseURL: srv.URL, APIKey: "test-key", ModelName: "qwen-test"})
+
+	var partialThoughts []string
+	var final *model.LLMResponse
+	req := &model.LLMRequest{Contents: []*genai.Content{
+		{Role: "user", Parts: []*genai.Part{{Text: "9.11 vs 9.9?"}}},
+	}}
+	for resp, err := range m.GenerateContent(context.Background(), req, true) {
+		if err != nil {
+			t.Fatalf("GenerateContent: %v", err)
+		}
+		if resp.Partial && len(resp.Content.Parts) == 1 && resp.Content.Parts[0].Thought {
+			partialThoughts = append(partialThoughts, resp.Content.Parts[0].Text)
+		}
+		if !resp.Partial {
+			final = resp
+		}
+	}
+	if len(partialThoughts) != 2 {
+		t.Fatalf("expected 2 live thought partials, got %d: %v", len(partialThoughts), partialThoughts)
+	}
+	if final == nil {
+		t.Fatalf("no final response was yielded")
+	}
+	if len(final.Content.Parts) != 2 {
+		t.Fatalf("expected 2 parts (thought + message), got %d: %+v", len(final.Content.Parts), final.Content.Parts)
+	}
+	if p := final.Content.Parts[0]; !p.Thought || p.Text != "compare the decimals" {
+		t.Errorf("first part = %+v, want the accumulated reasoning text", p)
+	}
+	if p := final.Content.Parts[1]; p.Text != "9.9 is larger" {
+		t.Errorf("second part = %+v, want the done message", p)
+	}
+}
+
 // response.failed and bare error events must surface as errors, not as an
 // empty or truncated turn.
 func TestWireBody_StreamFailureEvents(t *testing.T) {

--- a/genai/openai/responses/wire_test.go
+++ b/genai/openai/responses/wire_test.go
@@ -1,0 +1,760 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
+// Copyright 2025 achetronic
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package responses
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"google.golang.org/adk/v2/model"
+	"google.golang.org/genai"
+)
+
+// minimalResponseJSON is a complete-enough /v1/responses payload for
+// convertResponse to succeed.
+const minimalResponseJSON = `{
+	"id": "resp_1",
+	"status": "completed",
+	"output": [{
+		"type": "message",
+		"id": "msg_1",
+		"role": "assistant",
+		"status": "completed",
+		"content": [{"type": "output_text", "text": "ok"}]
+	}],
+	"usage": {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2,
+		"input_tokens_details": {"cached_tokens": 0},
+		"output_tokens_details": {"reasoning_tokens": 0}}
+}`
+
+// captureBody points a Model at a local fake endpoint via BaseURL, fires one
+// non-streaming request, and returns the JSON body the openai-go SDK actually
+// put on the wire. Asserting on this (not on the pre-SDK params) is what
+// proves the bytes a real Responses API server receives are correct.
+func captureBody(t *testing.T, req *model.LLMRequest) map[string]any {
+	return captureBodyFor(t, Config{}, req)
+}
+
+// captureBodyFor mirrors captureBody but lets the test override Config
+// fields (the integration tier needs a real model name for its paid step);
+// BaseURL always points at the local fake server.
+func captureBodyFor(t *testing.T, cfg Config, req *model.LLMRequest) map[string]any {
+	t.Helper()
+
+	var captured []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, minimalResponseJSON)
+	}))
+	defer srv.Close()
+
+	cfg.BaseURL = srv.URL
+	if cfg.APIKey == "" {
+		cfg.APIKey = "test-key"
+	}
+	if cfg.ModelName == "" {
+		cfg.ModelName = "gpt-test"
+	}
+	m := New(cfg)
+
+	for _, err := range m.GenerateContent(context.Background(), req, false) {
+		if err != nil {
+			t.Fatalf("GenerateContent: %v", err)
+		}
+	}
+	if len(captured) == 0 {
+		t.Fatalf("server captured no request body")
+	}
+	var body map[string]any
+	if err := json.Unmarshal(captured, &body); err != nil {
+		t.Fatalf("unmarshal captured body: %v", err)
+	}
+	return body
+}
+
+// A replayed tool round-trip must reach the wire with store=false, the
+// encrypted-reasoning include, and "{}" (never "null") for nil tool
+// payloads: strict OpenAI-compatible parsers reject "null" there.
+func TestWireBody_StatelessToolReplay(t *testing.T) {
+	req := &model.LLMRequest{
+		Contents: []*genai.Content{
+			{Role: "user", Parts: []*genai.Part{{Text: "ping the tool"}}},
+			{Role: "model", Parts: []*genai.Part{
+				{FunctionCall: &genai.FunctionCall{ID: "call_1", Name: "ping"}},
+			}},
+			{Role: "user", Parts: []*genai.Part{
+				{FunctionResponse: &genai.FunctionResponse{ID: "call_1", Name: "ping"}},
+			}},
+		},
+	}
+
+	body := captureBody(t, req)
+
+	if body["model"] != "gpt-test" {
+		t.Errorf("model = %v, want gpt-test", body["model"])
+	}
+	if body["store"] != false {
+		t.Errorf("store = %v, want false", body["store"])
+	}
+	includes, _ := body["include"].([]any)
+	found := false
+	for _, inc := range includes {
+		if inc == "reasoning.encrypted_content" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("include = %v, want reasoning.encrypted_content", includes)
+	}
+
+	input, _ := body["input"].([]any)
+	if len(input) != 3 {
+		t.Fatalf("input items = %d, want 3", len(input))
+	}
+	call, _ := input[1].(map[string]any)
+	if call["type"] != "function_call" || call["arguments"] != "{}" {
+		t.Errorf("function_call item = %v, want arguments {}", call)
+	}
+	output, _ := input[2].(map[string]any)
+	if output["type"] != "function_call_output" || output["output"] != "{}" {
+		t.Errorf("function_call_output item = %v, want output {}", output)
+	}
+}
+
+// Streaming requests must carry stream=true on the wire, and the terminal
+// response.completed event must come back as the final aggregated turn.
+func TestWireBody_StreamFlag(t *testing.T) {
+	// SSE data fields are single-line, so the response JSON is compacted
+	// before being embedded in the terminal event.
+	var compact bytes.Buffer
+	if err := json.Compact(&compact, []byte(minimalResponseJSON)); err != nil {
+		t.Fatalf("compact: %v", err)
+	}
+
+	var captured []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		io.WriteString(w, "event: response.output_text.delta\n")
+		io.WriteString(w, `data: {"type":"response.output_text.delta","delta":"ok","sequence_number":1}`+"\n\n")
+		io.WriteString(w, "event: response.completed\n")
+		io.WriteString(w, `data: {"type":"response.completed","sequence_number":2,"response":`+compact.String()+"}\n\n")
+	}))
+	defer srv.Close()
+
+	m := New(Config{BaseURL: srv.URL, APIKey: "test-key", ModelName: "gpt-test"})
+
+	var final *model.LLMResponse
+	req := &model.LLMRequest{Contents: []*genai.Content{
+		{Role: "user", Parts: []*genai.Part{{Text: "hi"}}},
+	}}
+	for resp, err := range m.GenerateContent(context.Background(), req, true) {
+		if err != nil {
+			t.Fatalf("GenerateContent: %v", err)
+		}
+		if !resp.Partial {
+			final = resp
+		}
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(captured, &body); err != nil {
+		t.Fatalf("unmarshal captured body: %v", err)
+	}
+	if body["stream"] != true {
+		t.Errorf("stream = %v, want true", body["stream"])
+	}
+	if final == nil {
+		t.Fatalf("no final (non-partial) response was yielded")
+	}
+	if got := extractText(final.Content); got != "ok" {
+		t.Errorf("final text = %q, want ok", got)
+	}
+}
+
+// countingTransport records how many requests pass through so tests can
+// prove an injected client actually carries the traffic.
+type countingTransport struct {
+	base http.RoundTripper
+	hits int
+}
+
+func (c *countingTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	c.hits++
+	return c.base.RoundTrip(r)
+}
+
+// A custom HTTP client injected through HTTPOptions must carry the request:
+// consumers rely on it for OAuth transports, proxies, and test servers.
+func TestCustomHTTPClientIsUsed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, minimalResponseJSON)
+	}))
+	defer srv.Close()
+
+	transport := &countingTransport{base: http.DefaultTransport}
+	m := New(Config{
+		BaseURL:     srv.URL,
+		APIKey:      "test-key",
+		ModelName:   "gpt-test",
+		HTTPOptions: HTTPOptions{Client: &http.Client{Transport: transport}},
+	})
+
+	req := &model.LLMRequest{Contents: []*genai.Content{
+		{Role: "user", Parts: []*genai.Part{{Text: "hi"}}},
+	}}
+	for _, err := range m.GenerateContent(context.Background(), req, false) {
+		if err != nil {
+			t.Fatalf("GenerateContent: %v", err)
+		}
+	}
+	if transport.hits != 1 {
+		t.Errorf("injected transport hits = %d, want 1", transport.hits)
+	}
+}
+
+// A terminal event whose payload carries malformed function arguments must
+// surface as an error, not degrade into the delta fallback: gateways that
+// omit output_item.done would otherwise silently drop the failure.
+func TestWireBody_StreamMalformedTerminalArguments(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		io.WriteString(w, "event: response.completed\n")
+		io.WriteString(w, `data: {"type":"response.completed","sequence_number":1,"response":{"id":"resp_1","status":"completed","output":[{"type":"function_call","id":"fc_1","call_id":"call_1","name":"delete_things","arguments":"{"}],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2,"input_tokens_details":{"cached_tokens":0},"output_tokens_details":{"reasoning_tokens":0}}}}`+"\n\n")
+	}))
+	defer srv.Close()
+
+	m := New(Config{BaseURL: srv.URL, APIKey: "test-key", ModelName: "gpt-test"})
+
+	req := &model.LLMRequest{Contents: []*genai.Content{
+		{Role: "user", Parts: []*genai.Part{{Text: "hi"}}},
+	}}
+	var gotErr error
+	for _, err := range m.GenerateContent(context.Background(), req, true) {
+		if err != nil {
+			gotErr = err
+		}
+	}
+	if gotErr == nil {
+		t.Fatalf("expected an error for malformed terminal arguments, got none")
+	}
+}
+
+// A terminal event whose output holds only unknown item types, with nothing
+// accumulated from the stream, must surface an error: yielding it as a
+// completed turn would persist an empty event with no trace of what was
+// dropped.
+func TestWireBody_StreamUnknownOnlyTerminal(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		io.WriteString(w, "event: response.completed\n")
+		io.WriteString(w, `data: {"type":"response.completed","sequence_number":1,"response":{"id":"resp_1","status":"completed","output":[{"type":"web_search_call","id":"ws_1","status":"completed"}],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2,"input_tokens_details":{"cached_tokens":0},"output_tokens_details":{"reasoning_tokens":0}}}}`+"\n\n")
+	}))
+	defer srv.Close()
+
+	m := New(Config{BaseURL: srv.URL, APIKey: "test-key", ModelName: "gpt-test"})
+
+	req := &model.LLMRequest{Contents: []*genai.Content{
+		{Role: "user", Parts: []*genai.Part{{Text: "hi"}}},
+	}}
+	var gotErr error
+	for resp, err := range m.GenerateContent(context.Background(), req, true) {
+		if err != nil {
+			gotErr = err
+			continue
+		}
+		if resp != nil && !resp.Partial && len(resp.Content.Parts) == 0 {
+			t.Fatalf("an empty completed turn was yielded: %+v", resp)
+		}
+	}
+	if !errors.Is(gotErr, ErrNoConsumableOutput) {
+		t.Fatalf("err = %v, want ErrNoConsumableOutput", gotErr)
+	}
+}
+
+// When a gateway sends complete output_item.done events but a terminal event
+// without aggregated output, the fallback must rebuild the turn from those
+// items: message IDs, phase, and encrypted reasoning survive, instead of
+// degrading to bare delta text.
+func TestWireBody_StreamFallbackPrefersDoneItems(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		io.WriteString(w, "event: response.output_text.delta\n")
+		io.WriteString(w, `data: {"type":"response.output_text.delta","delta":"hello","sequence_number":1}`+"\n\n")
+		io.WriteString(w, "event: response.output_item.done\n")
+		io.WriteString(w, `data: {"type":"response.output_item.done","sequence_number":2,"item":{"type":"reasoning","id":"rs_1","summary":[],"encrypted_content":"enc-blob"}}`+"\n\n")
+		io.WriteString(w, "event: response.output_item.done\n")
+		io.WriteString(w, `data: {"type":"response.output_item.done","sequence_number":3,"item":{"type":"message","id":"msg_1","role":"assistant","status":"completed","phase":"final_answer","content":[{"type":"output_text","text":"hello"}]}}`+"\n\n")
+		io.WriteString(w, "event: response.completed\n")
+		io.WriteString(w, `data: {"type":"response.completed","sequence_number":4,"response":{"id":"resp_1","status":"completed","output":[],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2,"input_tokens_details":{"cached_tokens":0},"output_tokens_details":{"reasoning_tokens":0}}}}`+"\n\n")
+	}))
+	defer srv.Close()
+
+	m := New(Config{BaseURL: srv.URL, APIKey: "test-key", ModelName: "gpt-test"})
+
+	var final *model.LLMResponse
+	req := &model.LLMRequest{Contents: []*genai.Content{
+		{Role: "user", Parts: []*genai.Part{{Text: "hi"}}},
+	}}
+	for resp, err := range m.GenerateContent(context.Background(), req, true) {
+		if err != nil {
+			t.Fatalf("GenerateContent: %v", err)
+		}
+		if !resp.Partial {
+			final = resp
+		}
+	}
+	if final == nil {
+		t.Fatalf("no final response was yielded")
+	}
+	if len(final.Content.Parts) != 2 {
+		t.Fatalf("expected 2 parts (reasoning + message), got %d: %+v", len(final.Content.Parts), final.Content.Parts)
+	}
+	thought := final.Content.Parts[0]
+	if !thought.Thought || thought.PartMetadata["encrypted_content"] != "enc-blob" {
+		t.Errorf("first part = %+v, want a thought carrying encrypted content", thought)
+	}
+	msg := final.Content.Parts[1]
+	if msg.Text != "hello" || msg.PartMetadata["message_id"] != "msg_1" || msg.PartMetadata["phase"] != "final_answer" {
+		t.Errorf("second part = %+v, want text with message_id and phase", msg)
+	}
+}
+
+// closeTrackingBody flags when the response body is closed so tests can
+// prove the stream does not leak the connection.
+type closeTrackingBody struct {
+	io.Reader
+	closed *bool
+}
+
+func (b closeTrackingBody) Close() error {
+	*b.closed = true
+	return nil
+}
+
+type sseTransport struct {
+	payload string
+	closed  *bool
+}
+
+func (s *sseTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: 200,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:       closeTrackingBody{Reader: bytes.NewReader([]byte(s.payload)), closed: s.closed},
+		Request:    r,
+	}, nil
+}
+
+// The stream returns early on terminal events, so the response body must be
+// closed explicitly; leaving it open leaks the connection.
+func TestStreamBodyClosed(t *testing.T) {
+	var compact bytes.Buffer
+	if err := json.Compact(&compact, []byte(minimalResponseJSON)); err != nil {
+		t.Fatalf("compact: %v", err)
+	}
+	closed := false
+	payload := "event: response.completed\n" +
+		`data: {"type":"response.completed","sequence_number":1,"response":` + compact.String() + "}\n\n"
+	m := New(Config{
+		APIKey:      "test-key",
+		ModelName:   "gpt-test",
+		BaseURL:     "http://fake.local",
+		HTTPOptions: HTTPOptions{Client: &http.Client{Transport: &sseTransport{payload: payload, closed: &closed}}},
+	})
+
+	req := &model.LLMRequest{Contents: []*genai.Content{
+		{Role: "user", Parts: []*genai.Part{{Text: "hi"}}},
+	}}
+	for _, err := range m.GenerateContent(context.Background(), req, true) {
+		if err != nil {
+			t.Fatalf("GenerateContent: %v", err)
+		}
+	}
+	if !closed {
+		t.Fatalf("stream body was not closed")
+	}
+}
+
+// Done items that cover only part of the turn (e.g. reasoning) must not
+// discard text that streamed as bare deltas: the consumer already saw it,
+// so the final event and the next turn's history must keep it.
+func TestWireBody_StreamFallbackMergesUncoveredDeltas(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		io.WriteString(w, "event: response.output_text.delta\n")
+		io.WriteString(w, `data: {"type":"response.output_text.delta","delta":"hello","sequence_number":1}`+"\n\n")
+		io.WriteString(w, "event: response.output_item.done\n")
+		io.WriteString(w, `data: {"type":"response.output_item.done","sequence_number":2,"item":{"type":"reasoning","id":"rs_1","summary":[],"encrypted_content":"enc-blob"}}`+"\n\n")
+		io.WriteString(w, "event: response.completed\n")
+		io.WriteString(w, `data: {"type":"response.completed","sequence_number":3,"response":{"id":"resp_1","status":"completed","output":[],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2,"input_tokens_details":{"cached_tokens":0},"output_tokens_details":{"reasoning_tokens":0}}}}`+"\n\n")
+	}))
+	defer srv.Close()
+
+	m := New(Config{BaseURL: srv.URL, APIKey: "test-key", ModelName: "gpt-test"})
+
+	var final *model.LLMResponse
+	req := &model.LLMRequest{Contents: []*genai.Content{
+		{Role: "user", Parts: []*genai.Part{{Text: "hi"}}},
+	}}
+	for resp, err := range m.GenerateContent(context.Background(), req, true) {
+		if err != nil {
+			t.Fatalf("GenerateContent: %v", err)
+		}
+		if !resp.Partial {
+			final = resp
+		}
+	}
+	if final == nil {
+		t.Fatalf("no final response was yielded")
+	}
+	if len(final.Content.Parts) != 2 {
+		t.Fatalf("expected 2 parts (reasoning + merged text), got %d: %+v", len(final.Content.Parts), final.Content.Parts)
+	}
+	if !final.Content.Parts[0].Thought || final.Content.Parts[0].PartMetadata["encrypted_content"] != "enc-blob" {
+		t.Errorf("first part = %+v, want the reasoning item", final.Content.Parts[0])
+	}
+	if final.Content.Parts[1].Text != "hello" {
+		t.Errorf("second part = %+v, want the merged delta text", final.Content.Parts[1])
+	}
+}
+
+// Refusal deltas must be accumulated: without a terminal output or done
+// item, the fallback would otherwise persist an empty response.
+func TestWireBody_StreamRefusalDelta(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		io.WriteString(w, "event: response.refusal.delta\n")
+		io.WriteString(w, `data: {"type":"response.refusal.delta","delta":"I cannot help.","item_id":"msg_1","content_index":0,"output_index":0,"sequence_number":1}`+"\n\n")
+		io.WriteString(w, "event: response.completed\n")
+		io.WriteString(w, `data: {"type":"response.completed","sequence_number":2,"response":{"id":"resp_1","status":"completed","output":[],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2,"input_tokens_details":{"cached_tokens":0},"output_tokens_details":{"reasoning_tokens":0}}}}`+"\n\n")
+	}))
+	defer srv.Close()
+
+	m := New(Config{BaseURL: srv.URL, APIKey: "test-key", ModelName: "gpt-test"})
+
+	var final *model.LLMResponse
+	req := &model.LLMRequest{Contents: []*genai.Content{
+		{Role: "user", Parts: []*genai.Part{{Text: "hi"}}},
+	}}
+	for resp, err := range m.GenerateContent(context.Background(), req, true) {
+		if err != nil {
+			t.Fatalf("GenerateContent: %v", err)
+		}
+		if !resp.Partial {
+			final = resp
+		}
+	}
+	if final == nil {
+		t.Fatalf("no final response was yielded")
+	}
+	if len(final.Content.Parts) != 1 {
+		t.Fatalf("expected 1 part, got %d: %+v", len(final.Content.Parts), final.Content.Parts)
+	}
+	part := final.Content.Parts[0]
+	if part.Text != "I cannot help." || part.PartMetadata["refusal"] != true {
+		t.Errorf("part = %+v, want refusal text with refusal metadata", part)
+	}
+}
+
+// A turn with two messages where only the first produced a done event must
+// keep both: the covered message replays from its item (ID and phase
+// intact), and the second message's delta text is merged in rather than
+// masked by the first item's text.
+func TestWireBody_StreamFallbackKeepsUncoveredMessage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		io.WriteString(w, "event: response.output_text.delta\n")
+		io.WriteString(w, `data: {"type":"response.output_text.delta","delta":"let me look","item_id":"msg_1","output_index":0,"content_index":0,"sequence_number":1}`+"\n\n")
+		io.WriteString(w, "event: response.output_item.done\n")
+		io.WriteString(w, `data: {"type":"response.output_item.done","sequence_number":2,"output_index":0,"item":{"type":"message","id":"msg_1","role":"assistant","status":"completed","phase":"commentary","content":[{"type":"output_text","text":"let me look"}]}}`+"\n\n")
+		io.WriteString(w, "event: response.output_text.delta\n")
+		io.WriteString(w, `data: {"type":"response.output_text.delta","delta":"the answer is 4","item_id":"msg_2","output_index":1,"content_index":0,"sequence_number":3}`+"\n\n")
+		io.WriteString(w, "event: response.completed\n")
+		io.WriteString(w, `data: {"type":"response.completed","sequence_number":4,"response":{"id":"resp_1","status":"completed","output":[],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2,"input_tokens_details":{"cached_tokens":0},"output_tokens_details":{"reasoning_tokens":0}}}}`+"\n\n")
+	}))
+	defer srv.Close()
+
+	m := New(Config{BaseURL: srv.URL, APIKey: "test-key", ModelName: "gpt-test"})
+
+	var final *model.LLMResponse
+	req := &model.LLMRequest{Contents: []*genai.Content{
+		{Role: "user", Parts: []*genai.Part{{Text: "hi"}}},
+	}}
+	for resp, err := range m.GenerateContent(context.Background(), req, true) {
+		if err != nil {
+			t.Fatalf("GenerateContent: %v", err)
+		}
+		if !resp.Partial {
+			final = resp
+		}
+	}
+	if final == nil {
+		t.Fatalf("no final response was yielded")
+	}
+	if len(final.Content.Parts) != 2 {
+		t.Fatalf("expected 2 parts (done message + uncovered text), got %d: %+v", len(final.Content.Parts), final.Content.Parts)
+	}
+	first := final.Content.Parts[0]
+	if first.Text != "let me look" || first.PartMetadata["message_id"] != "msg_1" || first.PartMetadata["phase"] != "commentary" {
+		t.Errorf("first part = %+v, want the done message with identity", first)
+	}
+	if second := final.Content.Parts[1]; second.Text != "the answer is 4" {
+		t.Errorf("second part = %+v, want the uncovered final answer", second)
+	}
+}
+
+// The reverse gap: the first message streamed only as deltas while a later
+// message completed. The synthetic item must sort by output_index so the
+// final order matches the stream, not msg_2 before msg_1.
+func TestWireBody_StreamFallbackOrdersUncoveredMessage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		io.WriteString(w, "event: response.output_text.delta\n")
+		io.WriteString(w, `data: {"type":"response.output_text.delta","delta":"let me look","item_id":"msg_1","output_index":0,"content_index":0,"sequence_number":1}`+"\n\n")
+		io.WriteString(w, "event: response.output_item.done\n")
+		io.WriteString(w, `data: {"type":"response.output_item.done","sequence_number":2,"output_index":1,"item":{"type":"message","id":"msg_2","role":"assistant","status":"completed","phase":"final_answer","content":[{"type":"output_text","text":"the answer is 4"}]}}`+"\n\n")
+		io.WriteString(w, "event: response.completed\n")
+		io.WriteString(w, `data: {"type":"response.completed","sequence_number":3,"response":{"id":"resp_1","status":"completed","output":[],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2,"input_tokens_details":{"cached_tokens":0},"output_tokens_details":{"reasoning_tokens":0}}}}`+"\n\n")
+	}))
+	defer srv.Close()
+
+	m := New(Config{BaseURL: srv.URL, APIKey: "test-key", ModelName: "gpt-test"})
+
+	var final *model.LLMResponse
+	req := &model.LLMRequest{Contents: []*genai.Content{
+		{Role: "user", Parts: []*genai.Part{{Text: "hi"}}},
+	}}
+	for resp, err := range m.GenerateContent(context.Background(), req, true) {
+		if err != nil {
+			t.Fatalf("GenerateContent: %v", err)
+		}
+		if !resp.Partial {
+			final = resp
+		}
+	}
+	if final == nil {
+		t.Fatalf("no final response was yielded")
+	}
+	if len(final.Content.Parts) != 2 {
+		t.Fatalf("expected 2 parts, got %d: %+v", len(final.Content.Parts), final.Content.Parts)
+	}
+	first := final.Content.Parts[0]
+	if first.Text != "let me look" || first.PartMetadata["message_id"] != "msg_1" {
+		t.Errorf("first part = %+v, want the uncovered message with its ID", first)
+	}
+	second := final.Content.Parts[1]
+	if second.Text != "the answer is 4" || second.PartMetadata["phase"] != "final_answer" {
+		t.Errorf("second part = %+v, want the done message", second)
+	}
+}
+
+// Base64 documents must reach the wire with both file_data and a filename:
+// the API identifies the document type by the extension.
+func TestWireBody_InlineDocumentCarriesFilename(t *testing.T) {
+	req := &model.LLMRequest{
+		Contents: []*genai.Content{
+			{Role: "user", Parts: []*genai.Part{
+				{Text: "summarize this"},
+				{InlineData: &genai.Blob{MIMEType: "application/pdf", Data: []byte("fake-pdf")}},
+			}},
+		},
+	}
+
+	body := captureBody(t, req)
+
+	input, _ := body["input"].([]any)
+	if len(input) != 1 {
+		t.Fatalf("input items = %d, want 1", len(input))
+	}
+	msg, _ := input[0].(map[string]any)
+	contents, _ := msg["content"].([]any)
+	if len(contents) != 2 {
+		t.Fatalf("content parts = %d, want 2", len(contents))
+	}
+	file, _ := contents[1].(map[string]any)
+	if file["type"] != "input_file" {
+		t.Fatalf("second part = %v, want input_file", file)
+	}
+	if file["filename"] != "input.pdf" {
+		t.Errorf("filename = %v, want input.pdf", file["filename"])
+	}
+	if data, _ := file["file_data"].(string); data == "" {
+		t.Errorf("file_data missing from the wire body")
+	}
+}
+
+// Reasoning that streamed only as summary deltas must be prepended when the
+// done items carry no reasoning item of their own.
+func TestWireBody_StreamFallbackPrependsDeltaReasoning(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		io.WriteString(w, "event: response.reasoning_summary_text.delta\n")
+		io.WriteString(w, `data: {"type":"response.reasoning_summary_text.delta","delta":"thinking...","sequence_number":1}`+"\n\n")
+		io.WriteString(w, "event: response.output_item.done\n")
+		io.WriteString(w, `data: {"type":"response.output_item.done","sequence_number":2,"output_index":1,"item":{"type":"message","id":"msg_1","role":"assistant","status":"completed","phase":"final_answer","content":[{"type":"output_text","text":"done"}]}}`+"\n\n")
+		io.WriteString(w, "event: response.completed\n")
+		io.WriteString(w, `data: {"type":"response.completed","sequence_number":3,"response":{"id":"resp_1","status":"completed","output":[],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2,"input_tokens_details":{"cached_tokens":0},"output_tokens_details":{"reasoning_tokens":0}}}}`+"\n\n")
+	}))
+	defer srv.Close()
+
+	m := New(Config{BaseURL: srv.URL, APIKey: "test-key", ModelName: "gpt-test"})
+
+	var final *model.LLMResponse
+	req := &model.LLMRequest{Contents: []*genai.Content{
+		{Role: "user", Parts: []*genai.Part{{Text: "hi"}}},
+	}}
+	for resp, err := range m.GenerateContent(context.Background(), req, true) {
+		if err != nil {
+			t.Fatalf("GenerateContent: %v", err)
+		}
+		if !resp.Partial {
+			final = resp
+		}
+	}
+	if final == nil {
+		t.Fatalf("no final response was yielded")
+	}
+	if len(final.Content.Parts) != 2 {
+		t.Fatalf("expected 2 parts (thought + message), got %d: %+v", len(final.Content.Parts), final.Content.Parts)
+	}
+	if p := final.Content.Parts[0]; !p.Thought || p.Text != "thinking..." {
+		t.Errorf("first part = %+v, want the prepended delta reasoning", p)
+	}
+	if p := final.Content.Parts[1]; p.Text != "done" {
+		t.Errorf("second part = %+v, want the done message", p)
+	}
+}
+
+// response.failed and bare error events must surface as errors, not as an
+// empty or truncated turn.
+func TestWireBody_StreamFailureEvents(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload string
+	}{
+		{
+			"response.failed",
+			"event: response.failed\n" +
+				`data: {"type":"response.failed","sequence_number":1,"response":{"id":"resp_1","status":"failed","error":{"code":"server_error","message":"backend exploded"},"output":[],"usage":{"input_tokens":0,"output_tokens":0,"total_tokens":0,"input_tokens_details":{"cached_tokens":0},"output_tokens_details":{"reasoning_tokens":0}}}}` + "\n\n",
+		},
+		{
+			"error event",
+			"event: error\n" +
+				`data: {"type":"error","sequence_number":1,"code":"rate_limited","message":"slow down"}` + "\n\n",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				io.ReadAll(r.Body)
+				w.Header().Set("Content-Type", "text/event-stream")
+				io.WriteString(w, c.payload)
+			}))
+			defer srv.Close()
+
+			m := New(Config{BaseURL: srv.URL, APIKey: "test-key", ModelName: "gpt-test"})
+
+			req := &model.LLMRequest{Contents: []*genai.Content{
+				{Role: "user", Parts: []*genai.Part{{Text: "hi"}}},
+			}}
+			var gotErr error
+			for _, err := range m.GenerateContent(context.Background(), req, true) {
+				if err != nil {
+					gotErr = err
+				}
+			}
+			if gotErr == nil {
+				t.Fatalf("expected an error, got none")
+			}
+		})
+	}
+}
+
+// A history that ends mid-tool-call (the user cancelled the run) must not
+// replay the unpaired function_call: the API rejects a call whose output
+// never arrived. The reasoning item that led to the dropped call has no
+// follower left and must go too.
+func TestWireBody_DanglingCallDropped(t *testing.T) {
+	req := &model.LLMRequest{
+		Contents: []*genai.Content{
+			{Role: "user", Parts: []*genai.Part{{Text: "do the thing"}}},
+			{Role: "model", Parts: []*genai.Part{
+				{
+					Text:    "planning",
+					Thought: true,
+					PartMetadata: map[string]any{
+						"reasoning_id":      "rs_1",
+						"encrypted_content": "enc-blob",
+						"reasoning_origin":  "wrong-origin",
+					},
+				},
+				{FunctionCall: &genai.FunctionCall{ID: "call_cancelled", Name: "slow_tool"}},
+			}},
+			{Role: "user", Parts: []*genai.Part{{Text: "never mind, tell me a joke"}}},
+		},
+	}
+
+	body := captureBody(t, req)
+
+	input, _ := body["input"].([]any)
+	if len(input) != 2 {
+		t.Fatalf("input items = %d, want 2 (both user messages only): %v", len(input), input)
+	}
+	for i, raw := range input {
+		item, _ := raw.(map[string]any)
+		if item["type"] == "function_call" || item["type"] == "reasoning" {
+			t.Errorf("input[%d] = %v, want the dangling call and its reasoning dropped", i, item)
+		}
+	}
+}
+
+// The reverse orphan: an output whose call was lost to compaction must be
+// dropped too.
+func TestWireBody_OrphanOutputDropped(t *testing.T) {
+	req := &model.LLMRequest{
+		Contents: []*genai.Content{
+			{Role: "user", Parts: []*genai.Part{
+				{FunctionResponse: &genai.FunctionResponse{ID: "call_lost", Name: "slow_tool"}},
+				{Text: "carry on"},
+			}},
+		},
+	}
+
+	body := captureBody(t, req)
+
+	input, _ := body["input"].([]any)
+	if len(input) != 1 {
+		t.Fatalf("input items = %d, want 1 (the text only): %v", len(input), input)
+	}
+	item, _ := input[0].(map[string]any)
+	if item["type"] == "function_call_output" {
+		t.Errorf("input[0] = %v, want the orphan output dropped", item)
+	}
+}


### PR DESCRIPTION
## What

Adds a `genai/openai/responses` package that talks to the OpenAI [Responses API](https://platform.openai.com/docs/api-reference/responses) (`/v1/responses`), nested under the openai provider next to the Chat Completions client. This matches the layout of the official OpenAI Go SDK, which keeps Chat Completions in its root package and Responses in a `responses` subpackage. The adapter implements the same `model.LLM` interface, so it drops in wherever the other adapters are used.

## Why

`genai/openai` speaks Chat Completions, which is the right fit for OpenAI-compatible gateways. The Responses API is OpenAI's recommended interface and the only way to reach some features: native reasoning items with encrypted content, phase labels on gpt-5.3-codex class models, and some provider tools (Qwen's `web_search_image` is Responses-only). A dedicated adapter lets users pick whichever endpoint their backend needs.

## Design

- Stateless: ADK owns the conversation state; each request replays the full history as input items with `store=false`. Encrypted reasoning content is requested so chains of thought survive across turns, and it is only replayed to the channel that produced it (a fingerprint of base URL, API key, and model); otherwise the turn degrades to fresh reasoning instead of failing.
- Message identity (ID, phase, status) and refusals survive the stateless round trip.
- Tool schemas go out strict when the strict subset can express them faithfully, with a non-strict fallback where it cannot (unions at the root, unsupported keywords, unresolvable references). Structured output works from both the typed `ResponseSchema` and a raw `ResponseJsonSchema`.
- Streaming rebuilds the final turn even on degraded gateways: terminal aggregated output first, complete `output_item.done` items next (keeping IDs, phase, and encrypted reasoning), bare deltas last, merged per output item so partially completed turns lose nothing.
- Images by URL and bytes; documents (PDF, Office formats, text, code) by URL and base64 upload with derived filenames. Audio is rejected with a clear error: the API's file inputs do not accept it.
- Nil tool payloads serialise as `{}`, never `null`, following the shared cross-adapter rule.

## Tests

The three tiers used by the sibling adapters: unit conversions, wire-body assertions against a local endpoint (the JSON the SDK actually sends), and OpenAPI schema validation plus an opt-in real-API step behind `-tags=integration`.

## Compatibility

Used in production in my own agent system with GPT 5.5, Qwen3.6 Plus, and Grok 4.3, through both the official endpoint and OpenAI-compatible gateways.
