### PR TITLE
fix: serialize nil FunctionCall.Args as {} instead of null

### DIFF
--- a/genai/openai/openai.go
+++ b/genai/openai/openai.go
@@ -410,6 +410,9 @@ func (m *Model) convertContentToMessages(content *genai.Content) ([]openai.ChatC
 			messages = append(messages, openai.ToolMessage(string(responseJSON), normalizedID))
 
 		case part.FunctionCall != nil:
+			if part.FunctionCall.Args == nil {
+				part.FunctionCall.Args = make(map[string]any)
+			}
 			argsJSON, err := json.Marshal(part.FunctionCall.Args)
 			if err != nil {
 				return nil, fmt.Errorf("failed to marshal function args: %w", err)


### PR DESCRIPTION
When a tool has no parameters (e.g. exit_loop), FunctionCall.Args is nil. json.Marshal(nil) produces the JSON string "null", which is rejected by Qwen's Jinja template. Adding a guard that replaces nil with an empty map ensures the output is always "{}".
