### PR TITLE
fix(openai): preserve cached prompt token usage

### DIFF
--- a/.agents/DECISIONS.md
+++ b/.agents/DECISIONS.md
@@ -256,6 +256,21 @@ opt-in was missing.
   streaming request through the wire-capture fixture and asserts the JSON
   body has `stream: true` and `stream_options.include_usage: true`.
 
+### O9 - Cached prompt tokens map to `CachedContentTokenCount`
+
+OpenAI Chat Completions reports cache hits in
+`PromptTokensDetails.CachedTokens`. The count is a subset of `PromptTokens`, not
+an additional token bucket. `convertUsageMetadata` maps it to genai's
+`CachedContentTokenCount` while leaving `PromptTokenCount` and `TotalTokenCount`
+inclusive and unchanged.
+
+- **Why:** ADK's OpenTelemetry instrumentation emits
+  `gen_ai.usage.cache_read.input_tokens` from this field. Cost-aware consumers
+  can then apply the provider's discounted cache-read rate without changing the
+  total context usage.
+- **Missing details:** compatible providers that omit the field leave it at
+  zero; genai's `omitempty` keeps the detail absent on serialisation.
+
 ---
 
 ## Anthropic adapter (`genai/anthropic`)

--- a/genai/openai/openai.go
+++ b/genai/openai/openai.go
@@ -776,20 +776,21 @@ func convertInlineDataToPart(data *genai.Blob) (*openai.ChatCompletionContentPar
 // CompletionTokensDetails.ReasoningTokens is the count of hidden reasoning
 // tokens billed as output tokens by OpenAI reasoning models (o-series,
 // gpt-5.x) and by OpenAI-compatible providers exposing reasoning (DeepSeek,
-// Kimi K2/K2.6, Qwen3-Thinking). It is a documented part of the official
-// Chat Completions schema, so we always map it to genai's ThoughtsTokenCount
-// regardless of whether the provider also returns reasoning text. When the
-// provider does not emit reasoning tokens the field is zero, and genai
-// serialisation omits it via `omitempty`.
+// Kimi K2/K2.6, Qwen3-Thinking). PromptTokensDetails.CachedTokens is the
+// cache-hit subset of PromptTokens and is billed at a distinct input rate.
+// Both are documented parts of the official Chat Completions schema, so we
+// always map them to their genai counterparts. When a provider does not emit
+// a detail, the field is zero and genai serialisation omits it via `omitempty`.
 func convertUsageMetadata(usage openai.CompletionUsage) *genai.GenerateContentResponseUsageMetadata {
 	if usage.TotalTokens == 0 {
 		return nil
 	}
 	return &genai.GenerateContentResponseUsageMetadata{
-		PromptTokenCount:     int32(usage.PromptTokens),
-		CandidatesTokenCount: int32(usage.CompletionTokens),
-		TotalTokenCount:      int32(usage.TotalTokens),
-		ThoughtsTokenCount:   int32(usage.CompletionTokensDetails.ReasoningTokens),
+		PromptTokenCount:        int32(usage.PromptTokens),
+		CandidatesTokenCount:    int32(usage.CompletionTokens),
+		TotalTokenCount:         int32(usage.TotalTokens),
+		ThoughtsTokenCount:      int32(usage.CompletionTokensDetails.ReasoningTokens),
+		CachedContentTokenCount: int32(usage.PromptTokensDetails.CachedTokens),
 	}
 }
 

--- a/genai/openai/response_test.go
+++ b/genai/openai/response_test.go
@@ -505,20 +505,21 @@ func TestBuildStreamFinalResponse_WithReasoningContent(t *testing.T) {
 	})
 }
 
-// convertUsageMetadata must map CompletionTokensDetails.ReasoningTokens to
-// ThoughtsTokenCount. This is the only path through which billing/usage
-// systems downstream (e.g. Langfuse) can see how many hidden reasoning
-// tokens a turn consumed. Dropping the field silently — as the previous
-// implementation did — makes cost dashboards under-count and removes the
-// only signal callers have that a reasoning model actually reasoned.
-func TestConvertUsageMetadata_WithReasoningTokens(t *testing.T) {
-	t.Run("reasoning tokens map to ThoughtsTokenCount", func(t *testing.T) {
+// convertUsageMetadata must preserve the provider's detailed token buckets.
+// This is the only path through which billing/usage systems downstream (e.g.
+// Langfuse) can apply reasoning-output and cache-read prices. Dropping either
+// field silently makes cost dashboards inaccurate.
+func TestConvertUsageMetadata_WithTokenDetails(t *testing.T) {
+	t.Run("reasoning and cached tokens map to genai details", func(t *testing.T) {
 		usage := openai.CompletionUsage{
 			PromptTokens:     10,
 			CompletionTokens: 50,
 			TotalTokens:      60,
 			CompletionTokensDetails: openai.CompletionUsageCompletionTokensDetails{
 				ReasoningTokens: 42,
+			},
+			PromptTokensDetails: openai.CompletionUsagePromptTokensDetails{
+				CachedTokens: 8,
 			},
 		}
 		got := convertUsageMetadata(usage)
@@ -528,6 +529,9 @@ func TestConvertUsageMetadata_WithReasoningTokens(t *testing.T) {
 		if got.ThoughtsTokenCount != 42 {
 			t.Errorf("ThoughtsTokenCount = %d, want 42", got.ThoughtsTokenCount)
 		}
+		if got.CachedContentTokenCount != 8 {
+			t.Errorf("CachedContentTokenCount = %d, want 8", got.CachedContentTokenCount)
+		}
 		// Ensure the rest of the mapping is unchanged: a regression that
 		// rewrites the field assignments could silently zero one of these.
 		if got.PromptTokenCount != 10 || got.CandidatesTokenCount != 50 || got.TotalTokenCount != 60 {
@@ -535,11 +539,11 @@ func TestConvertUsageMetadata_WithReasoningTokens(t *testing.T) {
 		}
 	})
 
-	t.Run("zero reasoning tokens emit zero ThoughtsTokenCount", func(t *testing.T) {
+	t.Run("missing details emit zero detail counts", func(t *testing.T) {
 		// Providers that don't emit CompletionTokensDetails (Ollama,
-		// vanilla GPT-4o) must keep ThoughtsTokenCount=0. genai's
-		// `omitempty` then drops the field on serialisation so the
-		// observability backends don't see a misleading zero metric.
+		// vanilla GPT-4o) must keep detail counts at zero. genai's
+		// `omitempty` then drops the fields on serialisation so the
+		// observability backends don't see misleading zero metrics.
 		usage := openai.CompletionUsage{
 			PromptTokens:     1,
 			CompletionTokens: 2,
@@ -551,6 +555,9 @@ func TestConvertUsageMetadata_WithReasoningTokens(t *testing.T) {
 		}
 		if got.ThoughtsTokenCount != 0 {
 			t.Errorf("ThoughtsTokenCount = %d, want 0", got.ThoughtsTokenCount)
+		}
+		if got.CachedContentTokenCount != 0 {
+			t.Errorf("CachedContentTokenCount = %d, want 0", got.CachedContentTokenCount)
 		}
 	})
 }


### PR DESCRIPTION
The Chat Completions adapter drops `usage.prompt_tokens_details.cached_tokens` on conversion: `convertUsageMetadata` never reads `PromptTokensDetails`, so by the time usage reaches a consumer the cache-hit count is gone. Anything downstream that prices tokens (billing, Langfuse cost tables) has to charge the whole prompt at the full input rate, even when most of it was served from the provider's prompt cache at a discounted rate. On agentic workloads with long, stable prefixes the cached share dominates the prompt, so reported costs end up several times higher than what the provider actually bills.

`cached_tokens` is part of the documented Chat Completions usage schema, and it is a subset of `prompt_tokens`, not an extra bucket. The fix maps it to genai's `CachedContentTokenCount` and leaves `PromptTokenCount` / `TotalTokenCount` untouched, since those already include the cached portion. This also lines up with the other adapters: Anthropic has surfaced the cache-read portion in `CachedContentTokenCount` since 38aebf7, and Gemini reports `cachedContentTokenCount` natively, so the field now means the same thing everywhere.

Providers that don't emit the detail (Ollama, plain gpt-4o) leave the field at zero, and genai's `omitempty` drops it on serialisation — same behaviour as the existing `ThoughtsTokenCount` mapping. Both call sites (non-stream response and stream accumulator) go through `convertUsageMetadata`, so streaming is covered too.

The existing usage-conversion test now pins both the populated and the absent case, and there's a matching O8 entry in `.agents/DECISIONS.md`.
