### PR TITLE
feat(langfuse): expose TracerProviderOptions for custom trace-provider settings

### DIFF
--- a/.agents/LANGFUSE_PLUGIN.md
+++ b/.agents/LANGFUSE_PLUGIN.md
@@ -106,6 +106,12 @@ type Config struct {
     Environment string `yaml:"environment" json:"environment"` // Optional: deployment environment tag
     Release     string `yaml:"release" json:"release"`         // Optional: version tag
     ServiceName string `yaml:"serviceName,omitempty"`          // Optional: OTel service.name (default: "langfuse-adk")
+    Insecure    bool   `yaml:"insecure,omitempty"`             // Optional: plain-HTTP OTLP export (self-hosted/local only)
+
+    // Programmatic only (yaml:"-" json:"-"): extra options for the trace
+    // provider Setup builds, e.g. a custom ID generator or a sampler.
+    // See "two construction branches" under Setup() below.
+    TracerProviderOptions []sdktrace.TracerProviderOption
 }
 ```
 
@@ -132,7 +138,10 @@ Typical usage: HTTP middleware sets these before passing the context to the ADK 
 
 1. Creates an OTLP/HTTP exporter pointed at `{host}/api/public/otel/v1/traces` with Basic Auth
 2. Wraps it in `enrichingExporter`
-3. Creates ADK telemetry providers with a `BatchSpanProcessor`
+3. Creates ADK telemetry providers. Two construction branches:
+   - **Default** (`TracerProviderOptions` empty): passes a `BatchSpanProcessor` and the resource to the ADK, which builds the trace provider itself.
+   - **Custom** (`TracerProviderOptions` set): builds the trace provider in the plugin instead, because the ADK options only expose span processors and the resource. Wiring: resource merged over `resource.Default()` (mirrors the ADK's default-path assembly), the same `BatchSpanProcessor`, then the caller's options appended (so replace-semantics options win). The finished provider goes to the ADK via `WithTracerProvider`; on this path the ADK skips the OTLP trace exporters it would otherwise add from `OTEL_EXPORTER_OTLP_*` env vars.
+   - Each branch constructs its own `BatchSpanProcessor`. The processor starts its export goroutine on construction, so building one for the branch not taken would leak it.
 4. Sets the global OTel `TracerProvider`
 5. Creates the ADK plugin with all four callbacks
 6. Returns `(runner.PluginConfig, shutdown, error)`

--- a/README.md
+++ b/README.md
@@ -251,6 +251,37 @@ runnr, _ := runner.New(runner.Config{
 })
 ```
 
+### Custom TracerProvider Options
+
+`Config.TracerProviderOptions` (programmatic only, not readable from YAML/JSON)
+lets you inject trace-provider settings the default wiring does not expose —
+a custom ID generator, a sampler, span limits — while keeping the exporter and
+resource that `Setup` wires itself.
+
+The flagship use case is deterministic trace IDs derived from an external
+request/run ID, following Langfuse's recommended external-ID correlation
+pattern (`create_trace_id(seed=...)` in the Python SDK). Agents that pause for
+human input and resume in a later HTTP request otherwise produce a fresh
+random trace ID per request, splitting one logical run across several
+Langfuse traces:
+
+```go
+pluginCfg, shutdown, err := langfuse.Setup(&langfuse.Config{
+    PublicKey: os.Getenv("LANGFUSE_PUBLIC_KEY"),
+    SecretKey: os.Getenv("LANGFUSE_SECRET_KEY"),
+    TracerProviderOptions: []sdktrace.TracerProviderOption{
+        // myIDGenerator returns a trace ID derived from the run ID found in
+        // ctx (fall back to random when absent), so every execution of the
+        // same logical run lands in the same Langfuse trace.
+        sdktrace.WithIDGenerator(myIDGenerator),
+        // Optional: bound ingestion volume on high-traffic services.
+        // sdktrace.WithSampler(sdktrace.ParentBased(sdktrace.TraceIDRatioBased(0.1))),
+    },
+})
+```
+
+When the field is empty, `Setup` behaves exactly as before.
+
 ### Combining with ContextGuard
 
 ```go

--- a/README.md
+++ b/README.md
@@ -253,40 +253,40 @@ runnr, _ := runner.New(runner.Config{
 
 ### Custom TracerProvider Options
 
-`Config.TracerProviderOptions` (programmatic only, not readable from YAML/JSON)
-lets you inject trace-provider settings the default wiring does not expose —
-a custom ID generator, a sampler, span limits — while keeping the exporter and
-resource that `Setup` wires itself.
+`Config.TracerProviderOptions` passes extra options to the trace provider
+that `Setup` builds: a custom ID generator, a sampler, span limits. The
+exporter and resource that `Setup` wires itself stay in place. The field is
+programmatic only; it cannot be set from YAML/JSON.
 
-The flagship use case is deterministic trace IDs derived from an external
-request/run ID, following Langfuse's recommended external-ID correlation
-pattern (`create_trace_id(seed=...)` in the Python SDK). Agents that pause for
-human input and resume in a later HTTP request otherwise produce a fresh
-random trace ID per request, splitting one logical run across several
-Langfuse traces:
+The main use for this is pinning trace IDs to your own run IDs, so a paused
+agent that resumes in another HTTP request stays in one Langfuse trace.
+Without it, every request starts a fresh random trace ID and one logical run
+gets split across several traces. Langfuse recommends the same external-ID
+correlation pattern in its docs (`create_trace_id(seed=...)` in the Python
+SDK):
 
 ```go
 pluginCfg, shutdown, err := langfuse.Setup(&langfuse.Config{
     PublicKey: os.Getenv("LANGFUSE_PUBLIC_KEY"),
     SecretKey: os.Getenv("LANGFUSE_SECRET_KEY"),
     TracerProviderOptions: []sdktrace.TracerProviderOption{
-        // myIDGenerator returns a trace ID derived from the run ID found in
-        // ctx (fall back to random when absent), so every execution of the
-        // same logical run lands in the same Langfuse trace. Only the trace
-        // ID may be deterministic — span IDs must stay random, or resumed
-        // executions would collide inside the shared trace.
+        // myIDGenerator derives the trace ID from the run ID in ctx
+        // (random when absent), so every execution of the same logical
+        // run lands in the same Langfuse trace. Keep span IDs random:
+        // resumed executions would otherwise collide inside the shared
+        // trace.
         sdktrace.WithIDGenerator(myIDGenerator),
-        // Optional: bound ingestion volume on high-traffic services.
+        // Optional: cap ingestion volume on high-traffic services.
         // sdktrace.WithSampler(sdktrace.ParentBased(sdktrace.TraceIDRatioBased(0.1))),
     },
 })
 ```
 
-The options are applied after the resource and span processor `Setup` wires,
-so replace-semantics options (e.g. `sdktrace.WithResource`) override them.
-Because the ADK receives a preconfigured provider on this path, it skips the
-extra OTLP trace exporters it would otherwise wire from
-`OTEL_EXPORTER_OTLP_ENDPOINT` / `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`.
+The options run after the resource and span processor `Setup` wires, so an
+option with replace semantics (`sdktrace.WithResource`, for example) wins
+over what `Setup` set. Note that on this path the ADK receives a finished
+provider and skips the extra OTLP trace exporters it would otherwise wire
+from `OTEL_EXPORTER_OTLP_ENDPOINT` / `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`.
 
 When the field is empty, `Setup` behaves exactly as before.
 

--- a/README.md
+++ b/README.md
@@ -272,13 +272,21 @@ pluginCfg, shutdown, err := langfuse.Setup(&langfuse.Config{
     TracerProviderOptions: []sdktrace.TracerProviderOption{
         // myIDGenerator returns a trace ID derived from the run ID found in
         // ctx (fall back to random when absent), so every execution of the
-        // same logical run lands in the same Langfuse trace.
+        // same logical run lands in the same Langfuse trace. Only the trace
+        // ID may be deterministic — span IDs must stay random, or resumed
+        // executions would collide inside the shared trace.
         sdktrace.WithIDGenerator(myIDGenerator),
         // Optional: bound ingestion volume on high-traffic services.
         // sdktrace.WithSampler(sdktrace.ParentBased(sdktrace.TraceIDRatioBased(0.1))),
     },
 })
 ```
+
+The options are applied after the resource and span processor `Setup` wires,
+so replace-semantics options (e.g. `sdktrace.WithResource`) override them.
+Because the ADK receives a preconfigured provider on this path, it skips the
+extra OTLP trace exporters it would otherwise wire from
+`OTEL_EXPORTER_OTLP_ENDPOINT` / `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`.
 
 When the field is empty, `Setup` behaves exactly as before.
 

--- a/plugin/langfuse/langfuse.go
+++ b/plugin/langfuse/langfuse.go
@@ -112,18 +112,31 @@ func Setup(cfg *Config) (runner.PluginConfig, func(context.Context) error, error
 	enricher := newSpanEnricher()
 	wrapped := &enrichingExporter{inner: exporter, enricher: enricher}
 
-	telemetryOpts := []adktelemetry.Option{
-		adktelemetry.WithSpanProcessors(sdktrace.NewBatchSpanProcessor(wrapped)),
-		adktelemetry.WithResource(res),
-	}
-	if len(cfg.TracerProviderOptions) > 0 {
+	// NewBatchSpanProcessor starts its export goroutine on construction, so
+	// each branch below builds its own processor: constructing one eagerly
+	// for the branch not taken would leak that goroutine.
+	var telemetryOpts []adktelemetry.Option
+	if len(cfg.TracerProviderOptions) == 0 {
+		telemetryOpts = []adktelemetry.Option{
+			adktelemetry.WithSpanProcessors(sdktrace.NewBatchSpanProcessor(wrapped)),
+			adktelemetry.WithResource(res),
+		}
+	} else {
 		// The ADK telemetry setup only exposes span processors and the
 		// resource. When the caller needs deeper control over the trace
 		// provider (ID generator, sampler, span limits, ...), build it here
-		// with the same exporter/resource wiring plus the caller's options,
-		// and hand the finished provider over instead.
+		// with the same exporter wiring plus the caller's options, and hand
+		// the finished provider over instead.
+		//
+		// Merging over resource.Default() mirrors the resource the ADK
+		// assembles on the default path (telemetry.sdk.* attributes,
+		// OTEL_SERVICE_NAME / OTEL_RESOURCE_ATTRIBUTES environment variables).
+		tpRes, err := resource.Merge(resource.Default(), res)
+		if err != nil {
+			return runner.PluginConfig{}, nil, fmt.Errorf("langfuse: merge OTel resources: %w", err)
+		}
 		tpOpts := append([]sdktrace.TracerProviderOption{
-			sdktrace.WithResource(res),
+			sdktrace.WithResource(tpRes),
 			sdktrace.WithSpanProcessor(sdktrace.NewBatchSpanProcessor(wrapped)),
 		}, cfg.TracerProviderOptions...)
 		telemetryOpts = []adktelemetry.Option{

--- a/plugin/langfuse/langfuse.go
+++ b/plugin/langfuse/langfuse.go
@@ -112,10 +112,25 @@ func Setup(cfg *Config) (runner.PluginConfig, func(context.Context) error, error
 	enricher := newSpanEnricher()
 	wrapped := &enrichingExporter{inner: exporter, enricher: enricher}
 
-	providers, err := adktelemetry.New(context.Background(),
+	telemetryOpts := []adktelemetry.Option{
 		adktelemetry.WithSpanProcessors(sdktrace.NewBatchSpanProcessor(wrapped)),
 		adktelemetry.WithResource(res),
-	)
+	}
+	if len(cfg.TracerProviderOptions) > 0 {
+		// The ADK telemetry setup only exposes span processors and the
+		// resource. When the caller needs deeper control over the trace
+		// provider (ID generator, sampler, span limits, ...), build it here
+		// with the same exporter/resource wiring plus the caller's options,
+		// and hand the finished provider over instead.
+		tpOpts := append([]sdktrace.TracerProviderOption{
+			sdktrace.WithResource(res),
+			sdktrace.WithSpanProcessor(sdktrace.NewBatchSpanProcessor(wrapped)),
+		}, cfg.TracerProviderOptions...)
+		telemetryOpts = []adktelemetry.Option{
+			adktelemetry.WithTracerProvider(sdktrace.NewTracerProvider(tpOpts...)),
+		}
+	}
+	providers, err := adktelemetry.New(context.Background(), telemetryOpts...)
 	if err != nil {
 		return runner.PluginConfig{}, nil, fmt.Errorf("langfuse: create ADK telemetry providers: %w", err)
 	}

--- a/plugin/langfuse/setup_test.go
+++ b/plugin/langfuse/setup_test.go
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
+package langfuse
+
+import (
+	"context"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	oteltrace "go.opentelemetry.io/otel/trace"
+)
+
+// fixedIDGenerator is an sdktrace.IDGenerator that always returns the same
+// trace ID, standing in for real-world generators that derive trace IDs
+// deterministically from an external request/run ID.
+type fixedIDGenerator struct {
+	traceID oteltrace.TraceID
+}
+
+func (g *fixedIDGenerator) NewIDs(_ context.Context) (oteltrace.TraceID, oteltrace.SpanID) {
+	return g.traceID, oteltrace.SpanID{1, 2, 3, 4, 5, 6, 7, 8}
+}
+
+func (g *fixedIDGenerator) NewSpanID(_ context.Context, _ oteltrace.TraceID) oteltrace.SpanID {
+	return oteltrace.SpanID{8, 7, 6, 5, 4, 3, 2, 1}
+}
+
+// TestSetupAppliesTracerProviderOptions verifies that options supplied via
+// Config.TracerProviderOptions reach the trace provider Setup installs:
+// a custom ID generator controls the trace ID of new root spans, and an
+// additional span processor receives the finished spans.
+func TestSetupAppliesTracerProviderOptions(t *testing.T) {
+	prev := otel.GetTracerProvider()
+	defer otel.SetTracerProvider(prev)
+
+	wantTraceID := oteltrace.TraceID{0xde, 0xad, 0xbe, 0xef, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	recorder := tracetest.NewInMemoryExporter()
+
+	cfg := &Config{
+		PublicKey: "pk-test",
+		SecretKey: "sk-test",
+		Host:      "http://127.0.0.1:1", // never dialled: the batch exporter only flushes on shutdown
+		TracerProviderOptions: []sdktrace.TracerProviderOption{
+			sdktrace.WithIDGenerator(&fixedIDGenerator{traceID: wantTraceID}),
+			sdktrace.WithSpanProcessor(sdktrace.NewSimpleSpanProcessor(recorder)),
+		},
+	}
+
+	pluginCfg, shutdown, err := Setup(cfg)
+	if err != nil {
+		t.Fatalf("Setup returned error: %v", err)
+	}
+	if len(pluginCfg.Plugins) == 0 {
+		t.Fatalf("Setup returned no plugins")
+	}
+
+	_, span := otel.Tracer("setup-test").Start(context.Background(), "probe")
+	gotTraceID := span.SpanContext().TraceID()
+	span.End()
+
+	if gotTraceID != wantTraceID {
+		t.Errorf("root span trace ID = %s, want %s (custom IDGenerator not applied)", gotTraceID, wantTraceID)
+	}
+
+	spans := recorder.GetSpans()
+	if len(spans) != 1 {
+		t.Fatalf("additional span processor recorded %d spans, want 1", len(spans))
+	}
+	if spans[0].SpanContext.TraceID() != wantTraceID {
+		t.Errorf("recorded span trace ID = %s, want %s", spans[0].SpanContext.TraceID(), wantTraceID)
+	}
+
+	// Shut down with an already-cancelled context so the OTLP batch exporter
+	// does not attempt to flush to the fake endpoint.
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	_ = shutdown(cancelled)
+}
+
+// TestSetupWithoutTracerProviderOptions guards the default path: an empty
+// option list must keep the pre-existing behaviour and still install a
+// working global tracer provider.
+func TestSetupWithoutTracerProviderOptions(t *testing.T) {
+	prev := otel.GetTracerProvider()
+	defer otel.SetTracerProvider(prev)
+
+	cfg := &Config{
+		PublicKey: "pk-test",
+		SecretKey: "sk-test",
+		Host:      "http://127.0.0.1:1",
+	}
+
+	pluginCfg, shutdown, err := Setup(cfg)
+	if err != nil {
+		t.Fatalf("Setup returned error: %v", err)
+	}
+	if len(pluginCfg.Plugins) == 0 {
+		t.Fatalf("Setup returned no plugins")
+	}
+
+	_, span := otel.Tracer("setup-test").Start(context.Background(), "probe")
+	if !span.SpanContext().IsValid() {
+		t.Errorf("default path produced an invalid span context")
+	}
+	span.End()
+
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	_ = shutdown(cancelled)
+}

--- a/plugin/langfuse/setup_test.go
+++ b/plugin/langfuse/setup_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	oteltrace "go.opentelemetry.io/otel/trace"
@@ -40,9 +41,10 @@ func TestSetupAppliesTracerProviderOptions(t *testing.T) {
 	recorder := tracetest.NewInMemoryExporter()
 
 	cfg := &Config{
-		PublicKey: "pk-test",
-		SecretKey: "sk-test",
-		Host:      "http://127.0.0.1:1", // never dialled: the batch exporter only flushes on shutdown
+		PublicKey:   "pk-test",
+		SecretKey:   "sk-test",
+		Host:        "http://127.0.0.1:1", // never dialled: the batch exporter only flushes on shutdown
+		ServiceName: "setup-test-service",
 		TracerProviderOptions: []sdktrace.TracerProviderOption{
 			sdktrace.WithIDGenerator(&fixedIDGenerator{traceID: wantTraceID}),
 			sdktrace.WithSpanProcessor(sdktrace.NewSimpleSpanProcessor(recorder)),
@@ -71,6 +73,19 @@ func TestSetupAppliesTracerProviderOptions(t *testing.T) {
 	}
 	if spans[0].SpanContext.TraceID() != wantTraceID {
 		t.Errorf("recorded span trace ID = %s, want %s", spans[0].SpanContext.TraceID(), wantTraceID)
+	}
+
+	// The provider's resource must carry Setup's own wiring (service.name)
+	// merged over resource.Default() (telemetry.sdk.*).
+	resAttrs := make(map[attribute.Key]string)
+	for _, kv := range spans[0].Resource.Attributes() {
+		resAttrs[kv.Key] = kv.Value.Emit()
+	}
+	if got := resAttrs["service.name"]; got != "setup-test-service" {
+		t.Errorf("resource service.name = %q, want %q (Setup resource not applied)", got, "setup-test-service")
+	}
+	if _, ok := resAttrs["telemetry.sdk.name"]; !ok {
+		t.Errorf("resource is missing telemetry.sdk.name (resource.Default() not merged)")
 	}
 
 	// Shut down with an already-cancelled context so the OTLP batch exporter

--- a/plugin/langfuse/types.go
+++ b/plugin/langfuse/types.go
@@ -46,27 +46,26 @@ type Config struct {
 	// enabled, which is required for the public Langfuse Cloud endpoints.
 	Insecure bool `yaml:"insecure,omitempty" json:"insecure,omitempty"`
 
-	// TracerProviderOptions are additional options applied when constructing
-	// the underlying trace provider, on top of the exporter and resource that
-	// Setup wires itself. Use it to inject settings the default wiring does
-	// not expose, such as a custom ID generator (e.g. deterministic trace IDs
-	// derived from an external request/run ID, so paused-and-resumed agent
-	// invocations land in a single Langfuse trace), a sampler to bound
-	// ingestion volume, or span limits.
+	// TracerProviderOptions are extra options for the trace provider Setup
+	// builds, on top of the exporter and resource it wires itself. Use it
+	// for settings the default wiring does not expose: a custom ID generator
+	// (for example one that derives the trace ID from your own run ID, so a
+	// paused agent resuming in another HTTP request stays in one Langfuse
+	// trace), a sampler to cap ingestion volume, or span limits.
 	//
-	// The options are applied after Setup's own resource and span processor,
-	// so an option with replace semantics (e.g. sdktrace.WithResource)
+	// The options run after Setup's own resource and span processor, so an
+	// option with replace semantics (sdktrace.WithResource, for example)
 	// overrides what Setup wired. The resource Setup wires is merged over
-	// resource.Default(), matching the ADK's default-path resource assembly.
+	// resource.Default(), matching what the ADK assembles on its default
+	// path.
 	//
-	// Caveat: when this field is set, the ADK receives a preconfigured trace
-	// provider and skips the extra OTLP trace exporters it would otherwise
-	// wire from the OTEL_EXPORTER_OTLP_ENDPOINT /
-	// OTEL_EXPORTER_OTLP_TRACES_ENDPOINT environment variables. Log exporters
-	// are unaffected.
+	// Caveat: with this field set the ADK receives a finished trace provider
+	// and skips the extra OTLP trace exporters it would otherwise wire from
+	// the OTEL_EXPORTER_OTLP_ENDPOINT / OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+	// environment variables. Log exporters are unaffected.
 	//
-	// Programmatic only: this field cannot be populated from YAML/JSON
-	// configuration files. When empty, Setup behaves exactly as before.
+	// Programmatic only: the field cannot be set from YAML/JSON config
+	// files. When empty, Setup behaves exactly as before.
 	TracerProviderOptions []sdktrace.TracerProviderOption `yaml:"-" json:"-"`
 }
 

--- a/plugin/langfuse/types.go
+++ b/plugin/langfuse/types.go
@@ -54,6 +54,17 @@ type Config struct {
 	// invocations land in a single Langfuse trace), a sampler to bound
 	// ingestion volume, or span limits.
 	//
+	// The options are applied after Setup's own resource and span processor,
+	// so an option with replace semantics (e.g. sdktrace.WithResource)
+	// overrides what Setup wired. The resource Setup wires is merged over
+	// resource.Default(), matching the ADK's default-path resource assembly.
+	//
+	// Caveat: when this field is set, the ADK receives a preconfigured trace
+	// provider and skips the extra OTLP trace exporters it would otherwise
+	// wire from the OTEL_EXPORTER_OTLP_ENDPOINT /
+	// OTEL_EXPORTER_OTLP_TRACES_ENDPOINT environment variables. Log exporters
+	// are unaffected.
+	//
 	// Programmatic only: this field cannot be populated from YAML/JSON
 	// configuration files. When empty, Setup behaves exactly as before.
 	TracerProviderOptions []sdktrace.TracerProviderOption `yaml:"-" json:"-"`

--- a/plugin/langfuse/types.go
+++ b/plugin/langfuse/types.go
@@ -3,6 +3,10 @@
 
 package langfuse
 
+import (
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
 // Config holds the credentials and optional metadata needed to export traces
 // to a Langfuse instance via OTLP/HTTP.
 //
@@ -41,6 +45,18 @@ type Config struct {
 	// (e.g. plain-HTTP local development). The default (false) keeps TLS
 	// enabled, which is required for the public Langfuse Cloud endpoints.
 	Insecure bool `yaml:"insecure,omitempty" json:"insecure,omitempty"`
+
+	// TracerProviderOptions are additional options applied when constructing
+	// the underlying trace provider, on top of the exporter and resource that
+	// Setup wires itself. Use it to inject settings the default wiring does
+	// not expose, such as a custom ID generator (e.g. deterministic trace IDs
+	// derived from an external request/run ID, so paused-and-resumed agent
+	// invocations land in a single Langfuse trace), a sampler to bound
+	// ingestion volume, or span limits.
+	//
+	// Programmatic only: this field cannot be populated from YAML/JSON
+	// configuration files. When empty, Setup behaves exactly as before.
+	TracerProviderOptions []sdktrace.TracerProviderOption `yaml:"-" json:"-"`
 }
 
 // IsEnabled reports whether the minimum required credentials (PublicKey and


### PR DESCRIPTION
## What

Adds `Config.TracerProviderOptions` to the Langfuse plugin — an optional, programmatic-only field (excluded from YAML/JSON) that lets callers inject `sdktrace.TracerProviderOption`s into the trace provider that `Setup` builds: a custom ID generator, a sampler, span limits, or anything else the OTel SDK exposes.

When the field is empty, `Setup` behaves exactly as before — the default path is untouched and guarded by a test.

## Why

`Setup` hardwires the trace provider construction, and the ADK telemetry API only exposes span processors and the resource. Today there is no way to reach standard OTel provider settings without abandoning the plugin and re-wiring the whole exporter stack by hand.

The flagship use case is **deterministic trace IDs derived from an external request/run ID**, following Langfuse's documented external-ID correlation pattern (`create_trace_id(seed=...)` in the Python SDK). Agents that pause for human input and resume in a later HTTP request otherwise mint a fresh random trace ID per request, splitting one logical run across several Langfuse traces. A process restart between pause and resume makes the split unrecoverable, even for applications that manually stitch span contexts in memory. With a seeded ID generator, every execution of the same logical run lands in a single Langfuse trace — and the trace becomes directly addressable by the external run ID, which is handy for support tooling.

The same escape hatch covers samplers (bounding ingestion volume on high-traffic services) and span limits.

## How

- When `TracerProviderOptions` is set, `Setup` builds the `TracerProvider` itself with the same exporter wiring (batch processor around the enriching exporter), appends the caller's options, and hands the finished provider to the ADK via `telemetry.WithTracerProvider`.
- The provider resource is merged over `resource.Default()`, mirroring the resource the ADK assembles on the default path (`telemetry.sdk.*` attributes, `OTEL_SERVICE_NAME` / `OTEL_RESOURCE_ATTRIBUTES`).
- Caller options are applied last, so replace-semantics options (e.g. `sdktrace.WithResource`) can override what `Setup` wired.
- Each branch constructs its own `BatchSpanProcessor`: construction starts the export goroutine, so building one for the branch not taken would leak it.

## Known divergence (documented, not hidden)

With a preconfigured provider, the ADK skips the extra OTLP trace exporters it would otherwise wire from `OTEL_EXPORTER_OTLP_ENDPOINT` / `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` (log exporters are unaffected). This is inherent to `WithTracerProvider`'s take-over semantics in the ADK; it is called out on the field's doc comment and in the README.

## Testing

- `TestSetupAppliesTracerProviderOptions` — a custom ID generator controls root-span trace IDs, an additional span processor receives finished spans, and the provider resource carries both `Setup`'s own wiring (`service.name`) and the `resource.Default()` merge (`telemetry.sdk.*`).
- `TestSetupWithoutTracerProviderOptions` — guards the default path.
- `go test ./plugin/langfuse/ -count=1` passes, `go vet` and `gofmt` are clean.

The README gains a usage section with a worked ID-generator example, including the one sharp edge worth warning about: only the trace ID may be deterministic — span IDs must stay random, or resumed executions would collide inside the shared trace.
