### PR TITLE
feat(genai): support remote image URLs via FileData in the OpenAI and Anthropic clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,13 +134,13 @@ Both clients support:
 - Streaming and non-streaming responses
 - System instructions
 - Tool/function calling
-- Image inputs: inline bytes (`InlineData`, sent as base64) or remote URLs (`FileData`, passed through to the provider's image-URL field — nothing is downloaded or re-encoded)
+- Image inputs: inline bytes (`InlineData`, sent as base64) or remote URLs (`FileData`, passed through to the provider's image-URL field; nothing is downloaded or re-encoded)
 - Temperature, TopP, MaxOutputTokens, StopSequences
 - Extended thinking: classic budget API (`ThinkingBudgetTokens`) and adaptive effort API (`ThinkingEffort` + `ThinkingMode`)
 - Usage metadata
 - Custom HTTP headers (multi-value)
 
-Remote image URLs (`genai.Part.FileData`) are supported for image MIME types only — audio and documents still require uploaded bytes via `InlineData`. The URI must be `http(s)`: plain `http` is allowed because both clients also serve API-compatible gateways (Ollama, vLLM, LiteLLM, ...) that commonly fetch from local http endpoints, while `anthropic.com` itself only fetches publicly accessible `https` URLs and enforces that server-side. Invalid schemes and non-image MIME types fail with a clear error instead of being silently dropped.
+Remote image URLs (`genai.Part.FileData`) work for image MIME types only; audio and documents still need uploaded bytes via `InlineData`. The URI must be `http(s)`. Plain `http` is allowed because both clients also serve API-compatible gateways (Ollama, vLLM, LiteLLM, ...) that commonly fetch from local http endpoints; which URLs a hosted provider actually fetches is decided on its side. Note that `gs://` URIs are rejected even though `genai.FileData` documents them: neither provider can read from Google Cloud Storage, so for GCS-hosted files fetch the bytes and use `InlineData`. Invalid schemes and non-image MIME types fail with a clear error instead of being silently dropped.
 
 ## Session Service (Redis)
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Both clients support:
 - Usage metadata
 - Custom HTTP headers (multi-value)
 
-Remote image URLs (`genai.Part.FileData`) are supported for image MIME types only — audio and documents still require uploaded bytes via `InlineData`. Anthropic accepts only publicly accessible `https` URLs; the OpenAI client also allows plain `http` for OpenAI-compatible gateways (Ollama, vLLM, ...). Invalid schemes and non-image MIME types fail with a clear error instead of being silently dropped.
+Remote image URLs (`genai.Part.FileData`) are supported for image MIME types only — audio and documents still require uploaded bytes via `InlineData`. The URI must be `http(s)`: plain `http` is allowed because both clients also serve API-compatible gateways (Ollama, vLLM, LiteLLM, ...) that commonly fetch from local http endpoints, while `anthropic.com` itself only fetches publicly accessible `https` URLs and enforces that server-side. Invalid schemes and non-image MIME types fail with a clear error instead of being silently dropped.
 
 ## Session Service (Redis)
 

--- a/README.md
+++ b/README.md
@@ -134,11 +134,13 @@ Both clients support:
 - Streaming and non-streaming responses
 - System instructions
 - Tool/function calling
-- Image inputs (base64)
+- Image inputs: inline bytes (`InlineData`, sent as base64) or remote URLs (`FileData`, passed through to the provider's image-URL field — nothing is downloaded or re-encoded)
 - Temperature, TopP, MaxOutputTokens, StopSequences
 - Extended thinking: classic budget API (`ThinkingBudgetTokens`) and adaptive effort API (`ThinkingEffort` + `ThinkingMode`)
 - Usage metadata
 - Custom HTTP headers (multi-value)
+
+Remote image URLs (`genai.Part.FileData`) are supported for image MIME types only — audio and documents still require uploaded bytes via `InlineData`. Anthropic accepts only publicly accessible `https` URLs; the OpenAI client also allows plain `http` for OpenAI-compatible gateways (Ollama, vLLM, ...). Invalid schemes and non-image MIME types fail with a clear error instead of being silently dropped.
 
 ## Session Service (Redis)
 

--- a/genai/anthropic/anthropic.go
+++ b/genai/anthropic/anthropic.go
@@ -512,6 +512,14 @@ func (m *Model) convertContentToMessage(content *genai.Content) (*anthropic.Mess
 			blocks = append(blocks, *block)
 		}
 
+		if part.FileData != nil {
+			block, err := convertFileDataToBlock(part.FileData)
+			if err != nil {
+				return nil, err
+			}
+			blocks = append(blocks, *block)
+		}
+
 		if part.FunctionCall != nil {
 			input, err := common.MarshalToolPayload(part.FunctionCall.Args)
 			if err != nil {
@@ -929,6 +937,37 @@ func convertInlineDataToBlock(data *genai.Blob) (*anthropic.ContentBlockParamUni
 
 	default:
 		return nil, fmt.Errorf("unsupported inline data MIME type for Anthropic: %s", mediaType)
+	}
+}
+
+// convertFileDataToBlock converts URL-referenced file data to an Anthropic content block.
+// The FileURI is passed through verbatim as a remote URL source — nothing is downloaded
+// or base64-encoded. Only images are supported: Anthropic accepts a URL source for
+// images, whereas other media types require the bytes to be uploaded first (use
+// InlineData for those). Anthropic only fetches publicly accessible https URLs, so
+// other schemes are rejected here with a clear error instead of a provider-side 400.
+// Unsupported MIME types return an error, matching convertInlineDataToBlock's
+// fail-loud behaviour.
+func convertFileDataToBlock(data *genai.FileData) (*anthropic.ContentBlockParamUnion, error) {
+	if data == nil {
+		return nil, fmt.Errorf("file data is nil")
+	}
+	if !strings.HasPrefix(data.FileURI, "https://") {
+		return nil, fmt.Errorf("file data URI must be a publicly accessible https URL for Anthropic, got %q", data.FileURI)
+	}
+
+	switch data.MIMEType {
+	case "image/jpeg", "image/jpg", "image/png", "image/gif", "image/webp":
+		return &anthropic.ContentBlockParamUnion{
+			OfImage: &anthropic.ImageBlockParam{
+				Source: anthropic.ImageBlockParamSourceUnion{
+					OfURL: &anthropic.URLImageSourceParam{URL: data.FileURI},
+				},
+			},
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("unsupported file data MIME type for Anthropic: %s", data.MIMEType)
 	}
 }
 

--- a/genai/anthropic/anthropic.go
+++ b/genai/anthropic/anthropic.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"iter"
+	"mime"
 	"net/http"
 	"regexp"
 	"strings"
@@ -896,7 +897,7 @@ func convertInlineDataToBlock(data *genai.Blob) (*anthropic.ContentBlockParamUni
 		return nil, fmt.Errorf("inline data is nil")
 	}
 
-	mediaType := data.MIMEType
+	mediaType := normalizeMIMEType(data.MIMEType)
 	base64Data := base64.StdEncoding.EncodeToString(data.Data)
 
 	switch {
@@ -940,25 +941,26 @@ func convertInlineDataToBlock(data *genai.Blob) (*anthropic.ContentBlockParamUni
 	}
 }
 
-// convertFileDataToBlock converts URL-referenced file data to an Anthropic content block.
-// The FileURI is passed through verbatim as a remote URL source — nothing is downloaded
-// or base64-encoded. Only images are supported: Anthropic accepts a URL source for
-// images, whereas other media types require the bytes to be uploaded first (use
-// InlineData for those). Plain http URLs are allowed because the client also serves
-// Anthropic-compatible gateways via Config.BaseURL, which commonly fetch from local
-// http endpoints; anthropic.com itself only fetches publicly accessible https URLs
-// and enforces that on its side. Other schemes are rejected here with a clear error
-// instead of a provider-side 400. Unsupported MIME types return an error, matching
-// convertInlineDataToBlock's fail-loud behaviour.
+// convertFileDataToBlock maps a FileData part to an image block with a URL
+// source; the URI goes through verbatim, nothing is downloaded. Images only:
+// other media types need uploaded bytes (InlineData). Plain http is allowed
+// for gateways on Config.BaseURL. Other schemes error instead of being
+// silently dropped; gs://, the scheme genai.FileData documents, gets its own
+// message pointing at InlineData. DisplayName is dropped: image blocks have
+// no field for it.
 func convertFileDataToBlock(data *genai.FileData) (*anthropic.ContentBlockParamUnion, error) {
 	if data == nil {
 		return nil, fmt.Errorf("file data is nil")
+	}
+	if strings.HasPrefix(data.FileURI, "gs://") {
+		return nil, fmt.Errorf("file data URI %q is a Google Cloud Storage URI, which Anthropic cannot fetch: download the bytes and use InlineData instead", data.FileURI)
 	}
 	if !strings.HasPrefix(data.FileURI, "https://") && !strings.HasPrefix(data.FileURI, "http://") {
 		return nil, fmt.Errorf("file data URI must be an http(s) URL for Anthropic, got %q", data.FileURI)
 	}
 
-	switch data.MIMEType {
+	mediaType := normalizeMIMEType(data.MIMEType)
+	switch mediaType {
 	case "image/jpeg", "image/jpg", "image/png", "image/gif", "image/webp":
 		return &anthropic.ContentBlockParamUnion{
 			OfImage: &anthropic.ImageBlockParam{
@@ -969,8 +971,20 @@ func convertFileDataToBlock(data *genai.FileData) (*anthropic.ContentBlockParamU
 		}, nil
 
 	default:
-		return nil, fmt.Errorf("unsupported file data MIME type for Anthropic: %s", data.MIMEType)
+		return nil, fmt.Errorf("unsupported file data MIME type for Anthropic: %s", mediaType)
 	}
+}
+
+// normalizeMIMEType strips parameters from a MIME string ("image/png;
+// charset=utf-8" becomes "image/png") so the converters match on the media
+// type alone. Malformed strings come back unchanged and fail the match with
+// the caller's input in the error.
+func normalizeMIMEType(mimeType string) string {
+	mediaType, _, err := mime.ParseMediaType(mimeType)
+	if err != nil {
+		return mimeType
+	}
+	return mediaType
 }
 
 // hasContent returns true if the message has at least one content block.

--- a/genai/anthropic/anthropic.go
+++ b/genai/anthropic/anthropic.go
@@ -944,16 +944,18 @@ func convertInlineDataToBlock(data *genai.Blob) (*anthropic.ContentBlockParamUni
 // The FileURI is passed through verbatim as a remote URL source — nothing is downloaded
 // or base64-encoded. Only images are supported: Anthropic accepts a URL source for
 // images, whereas other media types require the bytes to be uploaded first (use
-// InlineData for those). Anthropic only fetches publicly accessible https URLs, so
-// other schemes are rejected here with a clear error instead of a provider-side 400.
-// Unsupported MIME types return an error, matching convertInlineDataToBlock's
-// fail-loud behaviour.
+// InlineData for those). Plain http URLs are allowed because the client also serves
+// Anthropic-compatible gateways via Config.BaseURL, which commonly fetch from local
+// http endpoints; anthropic.com itself only fetches publicly accessible https URLs
+// and enforces that on its side. Other schemes are rejected here with a clear error
+// instead of a provider-side 400. Unsupported MIME types return an error, matching
+// convertInlineDataToBlock's fail-loud behaviour.
 func convertFileDataToBlock(data *genai.FileData) (*anthropic.ContentBlockParamUnion, error) {
 	if data == nil {
 		return nil, fmt.Errorf("file data is nil")
 	}
-	if !strings.HasPrefix(data.FileURI, "https://") {
-		return nil, fmt.Errorf("file data URI must be a publicly accessible https URL for Anthropic, got %q", data.FileURI)
+	if !strings.HasPrefix(data.FileURI, "https://") && !strings.HasPrefix(data.FileURI, "http://") {
+		return nil, fmt.Errorf("file data URI must be an http(s) URL for Anthropic, got %q", data.FileURI)
 	}
 
 	switch data.MIMEType {

--- a/genai/anthropic/inline_data_test.go
+++ b/genai/anthropic/inline_data_test.go
@@ -115,9 +115,11 @@ func TestConvertInlineDataToBlock(t *testing.T) {
 
 // convertFileDataToBlock builds an OfImage block whose source is a remote URL
 // (OfURL) rather than base64 bytes, passing the FileURI through verbatim. Only
-// image MIME types are supported, and only https URIs: Anthropic fetches the
-// URL itself and accepts nothing but publicly accessible https, so other
-// schemes fail here with a clear error instead of a provider-side 400.
+// image MIME types are supported, and the URI must be http(s) — plain http is
+// allowed because Anthropic-compatible gateways behind Config.BaseURL commonly
+// fetch from local http endpoints (anthropic.com itself only fetches https and
+// enforces that server-side). Other schemes fail here with a clear error
+// instead of a provider-side 400.
 func TestConvertFileDataToBlock(t *testing.T) {
 	const fileURI = "https://cdn.example.com/cat.png"
 
@@ -136,7 +138,7 @@ func TestConvertFileDataToBlock(t *testing.T) {
 		{name: "text/plain unsupported", mime: "text/plain", uri: fileURI, wantErr: true},
 		{name: "video/mp4 unsupported", mime: "video/mp4", uri: fileURI, wantErr: true},
 		{name: "empty MIME type rejected", mime: "", uri: fileURI, wantErr: true},
-		{name: "plain http rejected", mime: "image/png", uri: "http://cdn.example.com/cat.png", wantErr: true},
+		{name: "plain http is allowed for gateways", mime: "image/png", uri: "http://localhost:8080/cat.png"},
 		{name: "gs scheme rejected", mime: "image/png", uri: "gs://bucket/cat.png", wantErr: true},
 		{name: "empty URI rejected", mime: "image/png", uri: "", wantErr: true},
 	}

--- a/genai/anthropic/inline_data_test.go
+++ b/genai/anthropic/inline_data_test.go
@@ -112,3 +112,64 @@ func TestConvertInlineDataToBlock(t *testing.T) {
 		}
 	})
 }
+
+// convertFileDataToBlock builds an OfImage block whose source is a remote URL
+// (OfURL) rather than base64 bytes, passing the FileURI through verbatim. Only
+// image MIME types are supported, and only https URIs: Anthropic fetches the
+// URL itself and accepts nothing but publicly accessible https, so other
+// schemes fail here with a clear error instead of a provider-side 400.
+func TestConvertFileDataToBlock(t *testing.T) {
+	const fileURI = "https://cdn.example.com/cat.png"
+
+	cases := []struct {
+		name    string
+		mime    string
+		uri     string
+		wantErr bool
+	}{
+		{name: "image/png", mime: "image/png", uri: fileURI},
+		{name: "image/jpeg", mime: "image/jpeg", uri: fileURI},
+		{name: "image/jpg alias", mime: "image/jpg", uri: fileURI},
+		{name: "image/gif", mime: "image/gif", uri: fileURI},
+		{name: "image/webp", mime: "image/webp", uri: fileURI},
+		{name: "application/pdf unsupported", mime: "application/pdf", uri: fileURI, wantErr: true},
+		{name: "text/plain unsupported", mime: "text/plain", uri: fileURI, wantErr: true},
+		{name: "video/mp4 unsupported", mime: "video/mp4", uri: fileURI, wantErr: true},
+		{name: "empty MIME type rejected", mime: "", uri: fileURI, wantErr: true},
+		{name: "plain http rejected", mime: "image/png", uri: "http://cdn.example.com/cat.png", wantErr: true},
+		{name: "gs scheme rejected", mime: "image/png", uri: "gs://bucket/cat.png", wantErr: true},
+		{name: "empty URI rejected", mime: "image/png", uri: "", wantErr: true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := convertFileDataToBlock(&genai.FileData{MIMEType: c.mime, FileURI: c.uri})
+			if c.wantErr {
+				if err == nil {
+					t.Errorf("expected error for MIME %q URI %q, got %#v", c.mime, c.uri, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got == nil || got.OfImage == nil {
+				t.Fatalf("expected OfImage variant, got %#v", got)
+			}
+			src := got.OfImage.Source.OfURL
+			if src == nil {
+				t.Fatalf("expected a URL image source, got %#v", got.OfImage.Source)
+			}
+			if src.URL != c.uri {
+				t.Errorf("URL = %q, want %q (must be passed through verbatim)", src.URL, c.uri)
+			}
+		})
+	}
+
+	t.Run("nil file data returns an error", func(t *testing.T) {
+		_, err := convertFileDataToBlock(nil)
+		if err == nil {
+			t.Errorf("expected error for nil file data")
+		}
+	})
+}

--- a/genai/anthropic/inline_data_test.go
+++ b/genai/anthropic/inline_data_test.go
@@ -5,6 +5,7 @@ package anthropic
 
 import (
 	"encoding/base64"
+	"strings"
 	"testing"
 
 	"google.golang.org/genai"
@@ -115,11 +116,9 @@ func TestConvertInlineDataToBlock(t *testing.T) {
 
 // convertFileDataToBlock builds an OfImage block whose source is a remote URL
 // (OfURL) rather than base64 bytes, passing the FileURI through verbatim. Only
-// image MIME types are supported, and the URI must be http(s) — plain http is
+// image MIME types are supported, and the URI must be http(s): plain http is
 // allowed because Anthropic-compatible gateways behind Config.BaseURL commonly
-// fetch from local http endpoints (anthropic.com itself only fetches https and
-// enforces that server-side). Other schemes fail here with a clear error
-// instead of a provider-side 400.
+// fetch from local http endpoints. Other schemes fail with a clear error.
 func TestConvertFileDataToBlock(t *testing.T) {
 	const fileURI = "https://cdn.example.com/cat.png"
 
@@ -134,6 +133,7 @@ func TestConvertFileDataToBlock(t *testing.T) {
 		{name: "image/jpg alias", mime: "image/jpg", uri: fileURI},
 		{name: "image/gif", mime: "image/gif", uri: fileURI},
 		{name: "image/webp", mime: "image/webp", uri: fileURI},
+		{name: "MIME parameters are stripped before matching", mime: "image/png; charset=utf-8", uri: fileURI},
 		{name: "application/pdf unsupported", mime: "application/pdf", uri: fileURI, wantErr: true},
 		{name: "text/plain unsupported", mime: "text/plain", uri: fileURI, wantErr: true},
 		{name: "video/mp4 unsupported", mime: "video/mp4", uri: fileURI, wantErr: true},
@@ -172,6 +172,15 @@ func TestConvertFileDataToBlock(t *testing.T) {
 		_, err := convertFileDataToBlock(nil)
 		if err == nil {
 			t.Errorf("expected error for nil file data")
+		}
+	})
+
+	// genai.FileData documents FileURI as a Google Cloud Storage URI, so
+	// callers holding a gs:// URI need to be told where to go instead.
+	t.Run("gs URI error points to InlineData", func(t *testing.T) {
+		_, err := convertFileDataToBlock(&genai.FileData{MIMEType: "image/png", FileURI: "gs://bucket/cat.png"})
+		if err == nil || !strings.Contains(err.Error(), "InlineData") {
+			t.Errorf("gs:// error should point the caller to InlineData, got: %v", err)
 		}
 	})
 }

--- a/genai/openai/openai.go
+++ b/genai/openai/openai.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"fmt"
 	"iter"
+	"mime"
 	"net/http"
 	"strings"
 	"sync"
@@ -734,7 +735,7 @@ func convertInlineDataToPart(data *genai.Blob) (*openai.ChatCompletionContentPar
 		return nil, fmt.Errorf("inline data is nil")
 	}
 
-	mediaType := data.MIMEType
+	mediaType := normalizeMIMEType(data.MIMEType)
 	base64Data := base64.StdEncoding.EncodeToString(data.Data)
 
 	switch {
@@ -778,24 +779,26 @@ func convertInlineDataToPart(data *genai.Blob) (*openai.ChatCompletionContentPar
 	}
 }
 
-// convertFileDataToPart converts URL-referenced file data to an OpenAI content part.
-// The FileURI is passed through verbatim to image_url — nothing is downloaded or
-// base64-encoded. Only images are supported: the Chat Completions API accepts a
-// remote URL for image_url, whereas audio and file inputs require the bytes to be
-// uploaded first (use InlineData for those). Plain http URLs are allowed because
-// OpenAI-compatible gateways (Ollama, vLLM, ...) commonly fetch from local http
-// endpoints; other schemes are rejected with a clear error instead of a
-// provider-side 400. Unsupported MIME types return an error, matching
-// convertInlineDataToPart's fail-loud behaviour.
+// convertFileDataToPart maps a FileData part to an image_url content part;
+// the URI goes through verbatim, nothing is downloaded. Images only: audio
+// and files need uploaded bytes (InlineData). Plain http is allowed for
+// OpenAI-compatible gateways (Ollama, vLLM, ...). Other schemes error
+// instead of being silently dropped; gs://, the scheme genai.FileData
+// documents, gets its own message pointing at InlineData. DisplayName is
+// dropped: image_url has no field for it.
 func convertFileDataToPart(data *genai.FileData) (*openai.ChatCompletionContentPartUnionParam, error) {
 	if data == nil {
 		return nil, fmt.Errorf("file data is nil")
+	}
+	if strings.HasPrefix(data.FileURI, "gs://") {
+		return nil, fmt.Errorf("file data URI %q is a Google Cloud Storage URI, which OpenAI cannot fetch: download the bytes and use InlineData instead", data.FileURI)
 	}
 	if !strings.HasPrefix(data.FileURI, "https://") && !strings.HasPrefix(data.FileURI, "http://") {
 		return nil, fmt.Errorf("file data URI must be an http(s) URL for OpenAI, got %q", data.FileURI)
 	}
 
-	switch data.MIMEType {
+	mediaType := normalizeMIMEType(data.MIMEType)
+	switch mediaType {
 	case "image/jpeg", "image/jpg", "image/png", "image/gif", "image/webp":
 		return &openai.ChatCompletionContentPartUnionParam{
 			OfImageURL: &openai.ChatCompletionContentPartImageParam{
@@ -807,8 +810,20 @@ func convertFileDataToPart(data *genai.FileData) (*openai.ChatCompletionContentP
 		}, nil
 
 	default:
-		return nil, fmt.Errorf("unsupported file data MIME type for OpenAI: %s", data.MIMEType)
+		return nil, fmt.Errorf("unsupported file data MIME type for OpenAI: %s", mediaType)
 	}
+}
+
+// normalizeMIMEType strips parameters from a MIME string ("image/png;
+// charset=utf-8" becomes "image/png") so the converters match on the media
+// type alone. Malformed strings come back unchanged and fail the match with
+// the caller's input in the error.
+func normalizeMIMEType(mimeType string) string {
+	mediaType, _, err := mime.ParseMediaType(mimeType)
+	if err != nil {
+		return mimeType
+	}
+	return mediaType
 }
 
 // convertUsageMetadata converts OpenAI usage stats to genai format.

--- a/genai/openai/openai.go
+++ b/genai/openai/openai.go
@@ -431,6 +431,13 @@ func (m *Model) convertContentToMessages(content *genai.Content) ([]openai.ChatC
 				return nil, err
 			}
 			mediaParts = append(mediaParts, *p)
+
+		case part.FileData != nil:
+			p, err := convertFileDataToPart(part.FileData)
+			if err != nil {
+				return nil, err
+			}
+			mediaParts = append(mediaParts, *p)
 		}
 	}
 
@@ -768,6 +775,39 @@ func convertInlineDataToPart(data *genai.Blob) (*openai.ChatCompletionContentPar
 
 	default:
 		return nil, fmt.Errorf("unsupported inline data MIME type for OpenAI: %s", mediaType)
+	}
+}
+
+// convertFileDataToPart converts URL-referenced file data to an OpenAI content part.
+// The FileURI is passed through verbatim to image_url — nothing is downloaded or
+// base64-encoded. Only images are supported: the Chat Completions API accepts a
+// remote URL for image_url, whereas audio and file inputs require the bytes to be
+// uploaded first (use InlineData for those). Plain http URLs are allowed because
+// OpenAI-compatible gateways (Ollama, vLLM, ...) commonly fetch from local http
+// endpoints; other schemes are rejected with a clear error instead of a
+// provider-side 400. Unsupported MIME types return an error, matching
+// convertInlineDataToPart's fail-loud behaviour.
+func convertFileDataToPart(data *genai.FileData) (*openai.ChatCompletionContentPartUnionParam, error) {
+	if data == nil {
+		return nil, fmt.Errorf("file data is nil")
+	}
+	if !strings.HasPrefix(data.FileURI, "https://") && !strings.HasPrefix(data.FileURI, "http://") {
+		return nil, fmt.Errorf("file data URI must be an http(s) URL for OpenAI, got %q", data.FileURI)
+	}
+
+	switch data.MIMEType {
+	case "image/jpeg", "image/jpg", "image/png", "image/gif", "image/webp":
+		return &openai.ChatCompletionContentPartUnionParam{
+			OfImageURL: &openai.ChatCompletionContentPartImageParam{
+				ImageURL: openai.ChatCompletionContentPartImageImageURLParam{
+					URL:    data.FileURI,
+					Detail: "auto",
+				},
+			},
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("unsupported file data MIME type for OpenAI: %s", data.MIMEType)
 	}
 }
 

--- a/genai/openai/tools_test.go
+++ b/genai/openai/tools_test.go
@@ -246,3 +246,60 @@ func TestConvertInlineDataToPart(t *testing.T) {
 		}
 	})
 }
+
+// convertFileDataToPart emits a remote-URL image part for the image MIME types
+// OpenAI supports. Unlike convertInlineDataToPart it passes the FileURI straight
+// through to image_url instead of base64-encoding bytes. Only images can be
+// referenced by URL (audio and files still require uploaded bytes), and the URI
+// must be http(s) — plain http is allowed because OpenAI-compatible gateways
+// (Ollama, vLLM, ...) commonly fetch from local http endpoints.
+func TestConvertFileDataToPart(t *testing.T) {
+	const fileURI = "https://cdn.example.com/cat.png"
+
+	cases := []struct {
+		name    string
+		mime    string
+		uri     string
+		wantErr bool
+	}{
+		{name: "image/png becomes a url image part", mime: "image/png", uri: fileURI},
+		{name: "image/jpeg also routes to image", mime: "image/jpeg", uri: fileURI},
+		{name: "image/webp also routes to image", mime: "image/webp", uri: fileURI},
+		{name: "plain http is allowed for gateways", mime: "image/png", uri: "http://localhost:8080/cat.png"},
+		{name: "audio is not supported via URL", mime: "audio/wav", uri: fileURI, wantErr: true},
+		{name: "pdf is not supported via URL", mime: "application/pdf", uri: fileURI, wantErr: true},
+		{name: "video is not supported via URL", mime: "video/mp4", uri: fileURI, wantErr: true},
+		{name: "empty MIME type rejected", mime: "", uri: fileURI, wantErr: true},
+		{name: "gs scheme rejected", mime: "image/png", uri: "gs://bucket/cat.png", wantErr: true},
+		{name: "data URI rejected (use InlineData)", mime: "image/png", uri: "data:image/png;base64,AAAA", wantErr: true},
+		{name: "empty URI rejected", mime: "image/png", uri: "", wantErr: true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := convertFileDataToPart(&genai.FileData{MIMEType: c.mime, FileURI: c.uri})
+			if c.wantErr {
+				if err == nil {
+					t.Errorf("expected error for MIME %q URI %q, got %#v", c.mime, c.uri, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got == nil || got.OfImageURL == nil {
+				t.Fatalf("expected OfImageURL, got %#v", got)
+			}
+			if url := got.OfImageURL.ImageURL.URL; url != c.uri {
+				t.Errorf("URL = %q, want the raw file URI %q (must not be base64-encoded)", url, c.uri)
+			}
+		})
+	}
+
+	t.Run("nil file data returns an error", func(t *testing.T) {
+		_, err := convertFileDataToPart(nil)
+		if err == nil {
+			t.Errorf("expected error for nil file data")
+		}
+	})
+}

--- a/genai/openai/tools_test.go
+++ b/genai/openai/tools_test.go
@@ -251,7 +251,7 @@ func TestConvertInlineDataToPart(t *testing.T) {
 // OpenAI supports. Unlike convertInlineDataToPart it passes the FileURI straight
 // through to image_url instead of base64-encoding bytes. Only images can be
 // referenced by URL (audio and files still require uploaded bytes), and the URI
-// must be http(s) — plain http is allowed because OpenAI-compatible gateways
+// must be http(s): plain http is allowed because OpenAI-compatible gateways
 // (Ollama, vLLM, ...) commonly fetch from local http endpoints.
 func TestConvertFileDataToPart(t *testing.T) {
 	const fileURI = "https://cdn.example.com/cat.png"
@@ -265,6 +265,7 @@ func TestConvertFileDataToPart(t *testing.T) {
 		{name: "image/png becomes a url image part", mime: "image/png", uri: fileURI},
 		{name: "image/jpeg also routes to image", mime: "image/jpeg", uri: fileURI},
 		{name: "image/webp also routes to image", mime: "image/webp", uri: fileURI},
+		{name: "MIME parameters are stripped before matching", mime: "image/png; charset=utf-8", uri: fileURI},
 		{name: "plain http is allowed for gateways", mime: "image/png", uri: "http://localhost:8080/cat.png"},
 		{name: "audio is not supported via URL", mime: "audio/wav", uri: fileURI, wantErr: true},
 		{name: "pdf is not supported via URL", mime: "application/pdf", uri: fileURI, wantErr: true},
@@ -300,6 +301,15 @@ func TestConvertFileDataToPart(t *testing.T) {
 		_, err := convertFileDataToPart(nil)
 		if err == nil {
 			t.Errorf("expected error for nil file data")
+		}
+	})
+
+	// genai.FileData documents FileURI as a Google Cloud Storage URI, so
+	// callers holding a gs:// URI need to be told where to go instead.
+	t.Run("gs URI error points to InlineData", func(t *testing.T) {
+		_, err := convertFileDataToPart(&genai.FileData{MIMEType: "image/png", FileURI: "gs://bucket/cat.png"})
+		if err == nil || !strings.Contains(err.Error(), "InlineData") {
+			t.Errorf("gs:// error should point the caller to InlineData, got: %v", err)
 		}
 	})
 }


### PR DESCRIPTION
## What

Adds `genai.Part.FileData` handling to the OpenAI Chat Completions and Anthropic clients: the `FileURI` is passed through **verbatim** as a remote image URL — nothing is downloaded or base64-encoded.

| Client | Target field |
|---|---|
| OpenAI Chat Completions | `image_url.url` |
| Anthropic | image block URL source (`Source.OfURL`) |

The change is purely additive: `InlineData` and every other part type are untouched.

## Why

Today a `FileData` part is **silently dropped** by both clients — the conversion loops only look at `Text`, `InlineData`, and function call/response parts. Anyone whose images already live at a public URL (CDN assets, object-storage presigned URLs, user uploads) has to download the bytes and re-encode them as base64 just to get them into the request, paying download latency and request-size overhead for data the provider could fetch directly. Both providers natively accept remote image URLs, so the adapters should too.

`FileData` is also the natural `genai` vocabulary for this: it is the URI-reference part type, and for providers without a file-upload API "a URL the provider fetches" is its only sensible meaning.

## How

- Each client gains a `convertFileData*` helper mirroring its existing `convertInlineData*` sibling, wired into the same part-conversion loop.
- **Only image MIME types** are accepted (`image/jpeg`, `image/jpg`, `image/png`, `image/gif`, `image/webp` — the documented set for both providers). Audio and documents still require uploaded bytes via `InlineData`; unsupported types return an error rather than being silently dropped, matching the existing `InlineData` fail-loud behaviour.
- **URI schemes are validated up front** so misuse fails with a clear adapter-side error instead of an opaque provider-side 400:
  - Both clients accept `http(s)` and reject everything else (`gs://`, empty URIs; `data:` URIs are rejected with a pointer to use `InlineData` instead).
  - Plain `http` is allowed because both clients also serve API-compatible gateways (Ollama, vLLM, LiteLLM, …) that commonly fetch from local http endpoints; `anthropic.com` itself only fetches publicly accessible `https` URLs and enforces that server-side, so that policy stays with the provider.

## Testing

- `TestConvertFileDataToBlock` (Anthropic) and `TestConvertFileDataToPart` (OpenAI): table-driven tests mirroring the `convertInlineData*` tests — every supported MIME type produces the URL variant with the URI passed through verbatim (asserted not base64-encoded); non-image MIME types, empty MIME, bad schemes, empty URIs, and nil inputs all return errors. Both tests pin the plain-`http` gateway case.
- `go test ./genai/anthropic/ ./genai/openai/ -count=1` passes; `go vet` and `gofmt` are clean.
- The README's supported-features list now documents the two image input forms and the per-provider URL scheme rules.

This has been running in production in our fork for several weeks, feeding CDN-hosted images to OpenAI-compatible providers without downloading bytes through the agent process.
