### PR TITLE
feat(openai): set stream_options.include_usage=true on streaming

### DIFF
--- a/.agents/DECISIONS.md
+++ b/.agents/DECISIONS.md
@@ -224,6 +224,38 @@ doesn't report an all-zero usage block (e.g. Ollama not returning usage).
 Both `FunctionCall.Args` and `FunctionResponse.Response` go through
 `common.MarshalToolPayload`.
 
+### O8 - Streaming requests always set `stream_options.include_usage=true`
+
+OpenAI's Chat Completions API only emits a final usage chunk on the SSE stream
+when the caller opts in via `stream_options.include_usage`. Without it, the
+`ChatCompletionAccumulator`'s `Usage` stays zero, and `buildStreamFinalResponse`
+already reads that accumulator (`convertUsageMetadata(acc.Usage)`) into the
+terminal `LLMResponse`'s `UsageMetadata` — so the plumbing was there, but the
+opt-in was missing.
+
+- **Decision:** `generateStream` sets `params.StreamOptions.IncludeUsage =
+  param.NewOpt(true)` before `NewStreaming`. The final `LLMResponse` on the
+  streaming path now carries populated `UsageMetadata`, matching the non-
+  streaming path (`generate` → `convertResponse`).
+- **Why:** consumers that price token spend (Langfuse, billing dashboards)
+  need usage on **every** turn, not just the non-streaming ones. Forcing
+  callers to pick between streaming UX and usage accounting turned the
+  adapter into an all-or-nothing choice.
+- **Symmetry with the non-streaming path:** `generate` returns usage via
+  `convertResponse(resp.Usage)`. Under D5 the two paths must be
+  behaviourally interchangeable; the include-usage opt-in restores that.
+- **Providers without the field:** Ollama and other OpenAI-compat servers
+  that don't implement `stream_options.include_usage` ignore it (see the
+  documented server behaviour), and O6 still drops the resulting all-zero
+  usage block. No behaviour change for those.
+- **Interrupted streams:** OpenAI's docs note that a broken stream may drop
+  the terminal usage chunk. That surfaces as an accumulator with zero usage
+  and O6 drops it — consistent with the pre-change behaviour on those failed
+  turns.
+- **Tests:** `wire_test.go::TestWireBody_StreamRequestsUsage` fires one
+  streaming request through the wire-capture fixture and asserts the JSON
+  body has `stream: true` and `stream_options.include_usage: true`.
+
 ---
 
 ## Anthropic adapter (`genai/anthropic`)

--- a/genai/openai/openai.go
+++ b/genai/openai/openai.go
@@ -21,6 +21,7 @@ import (
 	"github.com/achetronic/adk-utils-go/genai/common"
 	"github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/option"
+	"github.com/openai/openai-go/v3/packages/param"
 	"github.com/openai/openai-go/v3/shared"
 	"google.golang.org/adk/v2/model"
 	"google.golang.org/genai"
@@ -142,6 +143,12 @@ func (m *Model) generateStream(ctx context.Context, req *model.LLMRequest) iter.
 			yield(nil, err)
 			return
 		}
+
+		// Opt into the final usage chunk. Without stream_options.include_usage the
+		// server never emits it, the accumulator's Usage stays zero, and
+		// buildStreamFinalResponse yields a terminal LLMResponse with empty
+		// UsageMetadata — leaving consumers no way to price a streamed turn.
+		params.StreamOptions.IncludeUsage = param.NewOpt(true)
 
 		stream := m.client.Chat.Completions.NewStreaming(ctx, params)
 		acc := openai.ChatCompletionAccumulator{}

--- a/genai/openai/wire_test.go
+++ b/genai/openai/wire_test.go
@@ -100,3 +100,65 @@ func TestWireBody_NilFunctionResponse(t *testing.T) {
 		t.Errorf("tool content = %q, want \"{}\"", tool["content"])
 	}
 }
+
+// captureStreamBody is the streaming twin of captureBody: it points the model at
+// a fake SSE endpoint, fires one streaming request, and returns the JSON body
+// that hit the wire. Serves a minimal valid SSE stream so the accumulator drains
+// cleanly and generateStream yields its terminal LLMResponse.
+func captureStreamBody(t *testing.T, req *model.LLMRequest) map[string]any {
+	t.Helper()
+
+	var captured []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.WriteHeader(http.StatusOK)
+		io.WriteString(w,
+			"data: {\"id\":\"x\",\"object\":\"chat.completion.chunk\",\"created\":0,\"model\":\"m\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"ok\"},\"finish_reason\":null}]}\n\n"+
+				"data: {\"id\":\"x\",\"object\":\"chat.completion.chunk\",\"created\":0,\"model\":\"m\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n"+
+				"data: {\"id\":\"x\",\"object\":\"chat.completion.chunk\",\"created\":0,\"model\":\"m\",\"choices\":[],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":2,\"total_tokens\":3}}\n\n"+
+				"data: [DONE]\n\n")
+	}))
+	defer srv.Close()
+
+	m := New(Config{BaseURL: srv.URL, APIKey: "test-key", ModelName: "gpt-test"})
+
+	for _, err := range m.GenerateContent(context.Background(), req, true) {
+		if err != nil {
+			t.Fatalf("GenerateContent: %v", err)
+		}
+	}
+	if len(captured) == 0 {
+		t.Fatalf("server captured no request body")
+	}
+	var body map[string]any
+	if err := json.Unmarshal(captured, &body); err != nil {
+		t.Fatalf("unmarshal captured body: %v", err)
+	}
+	return body
+}
+
+// On the wire, a streaming request must set stream_options.include_usage=true.
+// Without this opt-in the OpenAI server never emits the terminal usage chunk,
+// the ChatCompletionAccumulator's Usage stays zero, and buildStreamFinalResponse
+// yields empty UsageMetadata — leaving consumers no way to price the turn.
+func TestWireBody_StreamRequestsUsage(t *testing.T) {
+	body := captureStreamBody(t, &model.LLMRequest{
+		Config: &genai.GenerateContentConfig{},
+		Contents: []*genai.Content{
+			{Role: "user", Parts: []*genai.Part{{Text: "hi"}}},
+		},
+	})
+
+	if body["stream"] != true {
+		t.Fatalf("stream = %v, want true", body["stream"])
+	}
+	opts, ok := body["stream_options"].(map[string]any)
+	if !ok {
+		t.Fatalf("stream_options missing or not an object: %v", body["stream_options"])
+	}
+	if opts["include_usage"] != true {
+		t.Errorf("stream_options.include_usage = %v, want true", opts["include_usage"])
+	}
+}


### PR DESCRIPTION
## What

Sets `stream_options.include_usage = true` on the OpenAI adapter's streaming
path so `LLMResponse.UsageMetadata` is populated on the terminal streamed
response, matching the non-streaming path.

## Why

OpenAI's Chat Completions API only emits the final usage chunk when the caller
opts in via `stream_options.include_usage`. Without it, the
`ChatCompletionAccumulator.Usage` stays zero, and `buildStreamFinalResponse`
already reads that accumulator into the final `LLMResponse.UsageMetadata`
([openai.go#L246](https://github.com/achetronic/adk-utils-go/blob/master/genai/openai/openai.go#L246))
— so the conversion path was in place, but the wire opt-in was missing.

Concrete consequence for a downstream consumer: an ADK agent recording token
spend per turn (e.g. Langfuse cost tables, per-user billing) can currently
count non-streamed turns but not streamed ones. That forces the consumer to
either disable streaming (losing the UX) or accept blind spots in accounting.
This restores parity under D5 (providers must be behaviourally interchangeable).

## What changes

- `generateStream` sets `params.StreamOptions.IncludeUsage = param.NewOpt(true)` before `NewStreaming`.
- New wire test `TestWireBody_StreamRequestsUsage` fires one streaming request through a `captureStreamBody` fixture (SSE twin of the existing `captureBody`) and asserts the JSON body carries `stream: true` and `stream_options.include_usage: true`.
- New decision entry `O8` in `.agents/DECISIONS.md` records the wire-schema call, its symmetry with the non-streaming path, and its interaction with `O6` (all-zero usage dropped, so Ollama-class servers that don't implement the field are unaffected) and the documented interrupted-stream case.

## Testing

- `go test ./genai/...` — all three packages green (openai, anthropic, common).
- New test fails without the one-line change (asserts `stream_options.include_usage: true` on the wire); passes with it.
- No behaviour change on non-streaming; no behaviour change for OpenAI-compat servers that ignore the field.

## Notes

- The OpenAI docs note that an interrupted stream may drop the terminal usage chunk. That surfaces as `acc.Usage.TotalTokens == 0`, and `O6` (`convertUsageMetadata` returns nil for zero-total) drops it — same as the pre-change behaviour on failed turns.