### PR TITLE
fix(anthropic): merge authoritative usage from final message_delta events

### DIFF
--- a/.agents/DECISIONS.md
+++ b/.agents/DECISIONS.md
@@ -314,3 +314,19 @@ fabricates input. It is the caller's responsibility not to end on an assistant
 turn unless the target model supports prefill. Note `repairMessageHistory` can
 leave a history ending in assistant (after dropping a trailing orphan tool_use);
 that is the most likely way to hit this. Observed on `claude-sonnet-4-6`.
+
+### A11 - Final message_delta usage is authoritative (merged field-by-field)
+
+The SDK's `Message.Accumulate` only copies `output_tokens` from message_delta
+events, but the current Messages API defines the delta usage fields
+(`input_tokens`, `cache_creation_input_tokens`, `cache_read_input_tokens`) as
+cumulative totals. Anthropic itself already sends the true input-side split in
+message_start, so ignoring the delta fields is harmless there — but
+Anthropic-compatible endpoints built on engines that only know usage at end of
+stream put an estimate in message_start and the authoritative numbers
+(including the prompt-caching split) only in the final message_delta. Alibaba
+Cloud Model Studio documents exactly this shape. Without the merge, cache
+reads report as zero and `PromptTokenCount` stays at the estimate.
+`mergeDeltaUsage` folds delta usage into the accumulated message only for
+fields present on the wire (JSON field validity), so sparse deltas — the
+classic `output_tokens`-only shape — keep the message_start values.

--- a/genai/anthropic/anthropic.go
+++ b/genai/anthropic/anthropic.go
@@ -260,6 +260,8 @@ func (m *Model) generateStream(ctx context.Context, req *model.LLMRequest) iter.
 
 			// Yield partial text content
 			switch eventVariant := event.AsAny().(type) {
+			case anthropic.MessageDeltaEvent:
+				mergeDeltaUsage(&message.Usage, eventVariant.Usage)
 			case anthropic.ContentBlockDeltaEvent:
 				switch deltaVariant := eventVariant.Delta.AsAny().(type) {
 				case anthropic.TextDelta:
@@ -309,6 +311,30 @@ func (m *Model) generateStream(ctx context.Context, req *model.LLMRequest) iter.
 		llmResp.Partial = false
 		llmResp.TurnComplete = true
 		yield(llmResp, nil)
+	}
+}
+
+// mergeDeltaUsage folds the usage carried by a message_delta event into the
+// accumulated message's usage.
+//
+// The SDK's Message.Accumulate only copies output_tokens from deltas, but the
+// API reports the authoritative totals — including the prompt-caching split —
+// in the FINAL message_delta; the usage in message_start is a pre-generation
+// estimate. Some Anthropic-compatible gateways (e.g. new-api relaying an
+// OpenAI-protocol upstream) omit cache fields from message_start entirely and
+// only report them here, so without this merge cache hits read as zero and
+// input_tokens stays at the estimate. Fields absent from the wire are left
+// untouched (checked via JSON field presence), so responses whose deltas carry
+// only output_tokens keep the message_start values.
+func mergeDeltaUsage(usage *anthropic.Usage, delta anthropic.MessageDeltaUsage) {
+	if delta.JSON.InputTokens.Valid() {
+		usage.InputTokens = delta.InputTokens
+	}
+	if delta.JSON.CacheCreationInputTokens.Valid() {
+		usage.CacheCreationInputTokens = delta.CacheCreationInputTokens
+	}
+	if delta.JSON.CacheReadInputTokens.Valid() {
+		usage.CacheReadInputTokens = delta.CacheReadInputTokens
 	}
 }
 

--- a/genai/anthropic/stream_usage_test.go
+++ b/genai/anthropic/stream_usage_test.go
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
+package anthropic
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"google.golang.org/adk/v2/model"
+	"google.golang.org/genai"
+)
+
+// streamFinalResponse spins up a fake SSE Messages endpoint that replays the
+// given events, fires one STREAMING request and returns the final aggregated
+// response (the last non-partial one).
+func streamFinalResponse(t *testing.T, events []string) *model.LLMResponse {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		for _, e := range events {
+			_, _ = w.Write([]byte(e + "\n\n"))
+		}
+	}))
+	defer srv.Close()
+
+	m := New(Config{BaseURL: srv.URL, APIKey: "test-key", ModelName: "claude-test"})
+
+	req := &model.LLMRequest{
+		Config:   &genai.GenerateContentConfig{},
+		Contents: []*genai.Content{{Role: "user", Parts: []*genai.Part{{Text: "hi"}}}},
+	}
+
+	var final *model.LLMResponse
+	for resp, err := range m.GenerateContent(context.Background(), req, true) {
+		if err != nil {
+			t.Fatalf("GenerateContent: %v", err)
+		}
+		if !resp.Partial {
+			final = resp
+		}
+	}
+	if final == nil {
+		t.Fatalf("stream yielded no final response")
+	}
+	return final
+}
+
+func sse(event, data string) string {
+	return "event: " + event + "\ndata: " + data
+}
+
+// Gateways such as new-api (relaying an OpenAI-protocol upstream) send a
+// message_start whose usage is a pre-generation ESTIMATE with no cache
+// fields, and report the authoritative totals — including the prompt-caching
+// split — only in the final message_delta. The final response must carry the
+// delta's numbers, not the estimate. Event sequence captured from a live
+// new-api endpoint.
+func TestStreamUsage_FinalDeltaAuthoritative(t *testing.T) {
+	final := streamFinalResponse(t, []string{
+		sse("message_start", `{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"m","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":14105,"output_tokens":0}}}`),
+		sse("content_block_start", `{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`),
+		sse("content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ok"}}`),
+		sse("content_block_stop", `{"type":"content_block_stop","index":0}`),
+		sse("message_delta", `{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":1695,"output_tokens":695,"cache_creation_input_tokens":0,"cache_read_input_tokens":10624}}`),
+		sse("message_stop", `{"type":"message_stop"}`),
+	})
+
+	u := final.UsageMetadata
+	if u == nil {
+		t.Fatalf("final response has no usage metadata")
+	}
+	if got, want := u.PromptTokenCount, int32(1695+10624); got != want {
+		t.Errorf("PromptTokenCount = %d, want %d (delta totals, not the message_start estimate)", got, want)
+	}
+	if got, want := u.CachedContentTokenCount, int32(10624); got != want {
+		t.Errorf("CachedContentTokenCount = %d, want %d", got, want)
+	}
+	if got, want := u.CandidatesTokenCount, int32(695); got != want {
+		t.Errorf("CandidatesTokenCount = %d, want %d", got, want)
+	}
+	if !strings.Contains(final.Content.Parts[0].Text, "ok") {
+		t.Errorf("final text = %q, want it to contain the streamed delta", final.Content.Parts[0].Text)
+	}
+}
+
+// A message_delta carrying only output_tokens (the classic Anthropic wire
+// shape) must NOT clobber the usage from message_start: absent fields are
+// left untouched.
+func TestStreamUsage_SparseDeltaKeepsStartValues(t *testing.T) {
+	final := streamFinalResponse(t, []string{
+		sse("message_start", `{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"m","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":100,"output_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":30}}}`),
+		sse("content_block_start", `{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`),
+		sse("content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ok"}}`),
+		sse("content_block_stop", `{"type":"content_block_stop","index":0}`),
+		sse("message_delta", `{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":7}}`),
+		sse("message_stop", `{"type":"message_stop"}`),
+	})
+
+	u := final.UsageMetadata
+	if u == nil {
+		t.Fatalf("final response has no usage metadata")
+	}
+	if got, want := u.PromptTokenCount, int32(100+30); got != want {
+		t.Errorf("PromptTokenCount = %d, want %d (message_start values preserved)", got, want)
+	}
+	if got, want := u.CachedContentTokenCount, int32(30); got != want {
+		t.Errorf("CachedContentTokenCount = %d, want %d", got, want)
+	}
+	if got, want := u.CandidatesTokenCount, int32(7); got != want {
+		t.Errorf("CandidatesTokenCount = %d, want %d", got, want)
+	}
+}


### PR DESCRIPTION
The streaming path drops the prompt-caching split — and can misreport the prompt size itself — whenever the endpoint reports authoritative usage in the final `message_delta` rather than in `message_start`. The SDK's `Message.Accumulate` copies the full usage from `message_start` and then only `output_tokens` from delta events, so every other field keeps whatever `message_start` said.

Against Anthropic itself that is harmless: the true input-side numbers (including `cache_read_input_tokens`) are already known after prefill and arrive in `message_start`. But Anthropic-compatible endpoints built on engines that only total usage at end of stream send an **estimate** in `message_start` — without cache fields — and the authoritative numbers only in the final `message_delta`. Alibaba Cloud Model Studio (Bailian / DashScope, the Anthropic-compatible endpoint for the Qwen family) [documents exactly this shape](https://help.aliyun.com/zh/model-studio/anthropic-api-messages): "message_start carries only input_tokens and output_tokens; the full four usage fields arrive in message_delta". Gateways that relay such endpoints (new-api, LiteLLM-style proxies) inherit it. The observable failure: `CachedContentTokenCount` is always zero and `PromptTokenCount` is a tokenizer estimate, so billing/cost pipelines charge the whole prompt at the full input rate. Captured from a live endpoint (12,319-token prompt, 10,624 of it served from cache):

```
message_start:  "usage":{"input_tokens":14105,"output_tokens":0}
message_delta:  "usage":{"input_tokens":1695,"output_tokens":695,
                 "cache_creation_input_tokens":0,"cache_read_input_tokens":10624}
```

Merging the delta is also what the current official protocol asks for: `MessageDeltaUsage` defines `input_tokens` / `cache_creation_input_tokens` / `cache_read_input_tokens` as *"the cumulative number of … tokens"*, i.e. authoritative totals — `Accumulate`'s output_tokens-only copy predates those fields.

The fix is a `mergeDeltaUsage` step in the stream loop that folds delta usage into the accumulated message **only for fields actually present on the wire** (checked via the SDK's JSON field validity, not zero-comparison). That keeps all three endpoint behaviours correct: real Anthropic (delta repeats message_start values — overwrite is a no-op), estimate-in-start endpoints (estimate corrected to the authoritative totals), and the classic sparse shape where delta carries only `output_tokens` (absent fields leave message_start values untouched).

Two regression tests pin this down: a replay of the captured event sequence above (asserts the final response carries the delta totals, not the estimate) and a sparse-delta case (asserts message_start values survive). Verified against the live endpoint after the fix: second identical request reports `cached=12313` of a 12,319-token prompt. There's a matching A11 entry in `.agents/DECISIONS.md`.

Sibling of #28, which fixed the same cached-token loss for the Chat Completions adapter: with both merged, `CachedContentTokenCount` means the same thing across every adapter and transport.
