### PR TITLE
docs+style: writing rules in STYLE.md, ASCII cleanup across the repo

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -2,10 +2,12 @@
 
 Agent guidelines for working in the `adk-utils-go` repository.
 
-> Companion docs in `.agents/`: [DECISIONS.md](./DECISIONS.md) (per-provider
-> design decisions and their rationale) and [TODOS.md](./TODOS.md) (deferred
-> work and open review questions). Read DECISIONS.md before changing the
-> `genai/*` adapters: several behaviours there are deliberate and load-bearing.
+> Companion docs in `.agents/`: [STYLE.md](./STYLE.md) (how to write comments,
+> the README, and these docs; read it before writing any prose),
+> [DECISIONS.md](./DECISIONS.md) (per-provider design decisions and their
+> rationale) and [TODOS.md](./TODOS.md) (deferred work and open review
+> questions). Read DECISIONS.md before changing the `genai/*` adapters:
+> several behaviours there are deliberate and load-bearing.
 
 ## Project Overview
 
@@ -221,17 +223,17 @@ The `OpenAICompatibleEmbedding` implementation works with any OpenAI-compatible 
 3. **Event Loading**: Events are loaded fresh from Redis on each `Events().All()` call.
 4. **Session ID Generation**: If not provided, uses `time.Now().UnixNano()`.
 5. **State Tiers**: State keys are routed to separate Redis stores based on prefix, matching the canonical ADK behaviour:
-   - `app:` keys → `appstate:{appName}` HASH (shared across all users and sessions)
-   - `user:` keys → `userstate:{appName}:{userID}` HASH (shared across all sessions for that user)
-   - `temp:` keys → discarded (never persisted)
-   - Unprefixed keys → stored in the session JSON (per-session)
+   - `app:` keys -> `appstate:{appName}` HASH (shared across all users and sessions)
+   - `user:` keys -> `userstate:{appName}:{userID}` HASH (shared across all sessions for that user)
+   - `temp:` keys -> discarded (never persisted)
+   - Unprefixed keys -> stored in the session JSON (per-session)
 6. **State Tier Functions**: `extractStateDeltas` and `mergeStates` mirror `google.golang.org/adk/internal/sessionutils` (which is not importable from outside the ADK module).
 
 ### PostgreSQL Memory Service
 
 1. **pgvector Extension**: Required for semantic search. Schema auto-creates the extension if embedding model is configured.
 2. **Dimension Auto-Detection**: If `EmbeddingModel.Dimension()` returns 0, the service probes the model on init.
-3. **Search Fallback**: Vector search → full-text search → recent entries.
+3. **Search Fallback**: Vector search -> full-text search -> recent entries.
 4. **Upsert Behavior**: `AddSession` uses `ON CONFLICT ... DO UPDATE`.
 
 ### Memory Toolset
@@ -270,9 +272,9 @@ func (e *Events) All() iter.Seq[*session.Event]
 
 To avoid import cycles between `memory/postgres` and `tools/memory`, shared types and interfaces live in `memory/memorytypes`:
 
-- `EntryWithID` — memory entry with database row ID
-- `MemoryService` — base interface (mirrors ADK's `memory.Service`)
-- `ExtendedMemoryService` — adds `SearchWithID`, `UpdateMemory`, `DeleteMemory`
+- `EntryWithID`: memory entry with database row ID
+- `MemoryService`: base interface (mirrors ADK's `memory.Service`)
+- `ExtendedMemoryService`: adds `SearchWithID`, `UpdateMemory`, `DeleteMemory`
 
 Both `memory/postgres` and `tools/memory` import this package; neither imports the other.
 
@@ -308,14 +310,14 @@ cfg := guard.PluginConfig()           // runner.PluginConfig with BeforeModelCal
 
 ### Key Design
 
-- **Builder pattern**: `New()` + `Add()` + `PluginConfig()` — single-agent and multi-agent look identical
+- **Builder pattern**: `New()` + `Add()` + `PluginConfig()`: single-agent and multi-agent look identical
 - **Functional options**: `AgentOption` keeps common case zero-config, overrides via `WithMaxTokens`/`WithSlidingWindow`
 - **Per-agent strategies**: each agent gets its own strategy and summarizes with its own LLM
 - **Two callbacks**: `BeforeModelCallback` checks tokens and compacts; `AfterModelCallback` persists real token counts from the provider
 - **Calibrated heuristic**: bridges the timing gap between callbacks using a correction factor derived from real vs heuristic tokens of the previous call. Correction factor capped at 5.0x to prevent anomalous turns from distorting future estimates
-- **Full summary**: threshold strategy always summarizes the entire conversation (no recent tail). Post-compaction result is `[summary] + [continuation]` — always small and predictable
+- **Full summary**: threshold strategy always summarizes the entire conversation (no recent tail). Post-compaction result is `[summary] + [continuation]`: always small and predictable
 - **Robust failure handling**: conversation truncated to 80% of context window before summarization (prevents summarizer overflow). If LLM summarization fails, falls back to mechanical summary instead of passing through the bloated request
-- **ADK limitation**: `launcher.Config.PluginConfig` is a single field — the plugin internally dispatches by `ctx.AgentName()`
+- **ADK limitation**: `launcher.Config.PluginConfig` is a single field: the plugin internally dispatches by `ctx.AgentName()`
 - **State keys**: all keys suffixed with `{agentName}` to prevent cross-agent contamination in shared sessions
 
 ### State Keys
@@ -330,18 +332,18 @@ cfg := guard.PluginConfig()           // runner.PluginConfig with BeforeModelCal
 
 ### File Naming Convention
 
-- `contextguard.go` — public API, `BeforeModelCallback`, `AfterModelCallback`
-- `contextguard_unit_test.go` — 93 unit tests (mocks, no ADK flow)
-- `model_registry*.go` — ModelRegistry interface and implementations
-- `compaction_strategy_threshold.go` — token-threshold strategy (full summary, calibrated tokens, hardened)
-- `compaction_strategy_sliding_window.go` — sliding-window strategy (turn-count based, with recent tail)
-- `compaction_utils.go` — shared helpers: state persistence, summarization, token estimation, continuation injection, todo loading, conversation truncation
-- `compaction_strategy_multiturn_test.go` — 25 multi-turn session simulations with `simulateSession()` framework (threshold only)
-- `compaction_strategy_singleshot_test.go` — single-shot `Compact()` tests for both strategies, timing gap proofs
+- `contextguard.go`: public API, `BeforeModelCallback`, `AfterModelCallback`
+- `contextguard_unit_test.go`: 93 unit tests (mocks, no ADK flow)
+- `model_registry*.go`: ModelRegistry interface and implementations
+- `compaction_strategy_threshold.go`: token-threshold strategy (full summary, calibrated tokens, hardened)
+- `compaction_strategy_sliding_window.go`: sliding-window strategy (turn-count based, with recent tail)
+- `compaction_utils.go`: shared helpers: state persistence, summarization, token estimation, continuation injection, todo loading, conversation truncation
+- `compaction_strategy_multiturn_test.go`: 25 multi-turn session simulations with `simulateSession()` framework (threshold only)
+- `compaction_strategy_singleshot_test.go`: single-shot `Compact()` tests for both strategies, timing gap proofs
 
 ### CrushRegistry
 
-Built-in `ModelRegistry` using `charm.land/catwalk/pkg/embedded` — 564 models from 23 providers compiled into the binary. Zero network calls, no goroutines, no `Start()`/`Stop()` lifecycle. Defaults to 128k context / 4096 max tokens for unknown models.
+Built-in `ModelRegistry` using `charm.land/catwalk/pkg/embedded`: 564 models from 23 providers compiled into the binary. Zero network calls, no goroutines, no `Start()`/`Stop()` lifecycle. Defaults to 128k context / 4096 max tokens for unknown models.
 
 ### Stress Tests
 
@@ -368,9 +370,9 @@ See [INVESTIGATION_RESULTS.md](./INVESTIGATION_RESULTS.md) for the full architec
 
 ```
 BeforeModelCallback:
-  tokenCount() → calibrated estimate (correction capped at 5.0x)
-  if < threshold → pass through
-  if ≥ threshold → truncate for summarizer → summarize (fallback on error) → [summary] + [continuation]
+  tokenCount() -> calibrated estimate (correction capped at 5.0x)
+  if < threshold -> pass through
+  if ≥ threshold -> truncate for summarizer -> summarize (fallback on error) -> [summary] + [continuation]
 
 AfterModelCallback:
   persist PromptTokenCount for next step's calibration
@@ -378,11 +380,11 @@ AfterModelCallback:
 
 ---
 
-## LLM Adapters — tool_choice Mapping
+## LLM Adapters: tool_choice Mapping
 
 Both `genai/openai` and `genai/anthropic` translate `genai.GenerateContentConfig.ToolConfig.FunctionCallingConfig` into the provider-native `tool_choice` field during `applyGenerationConfig` / `buildMessageParams`. ADK propagates `ToolConfig` through `basic_processor.go` (`req.Config = clone(state.GenerateContentConfig)`), so the field arrives untouched at the adapter.
 
-Without this translation, callers setting `Mode: ANY` on an LLM agent see the setting silently dropped — the typical symptom being models like Kimi K2 or certain Claude variants producing plain-text replies that hand-format tool calls as prose, stranding agentic loops that require a native function call.
+Without this translation, callers setting `Mode: ANY` on an LLM agent see the setting silently dropped: the typical symptom being models like Kimi K2 or certain Claude variants producing plain-text replies that hand-format tool calls as prose, stranding agentic loops that require a native function call.
 
 ### Shared mapping (identical semantics across providers)
 
@@ -399,7 +401,7 @@ The multi-name fallback is a pragmatic choice: neither provider accepts a list o
 
 ### Tests
 
-Each adapter has a table-driven test (`openai_test.go` / `anthropic_test.go`) covering the seven relevant combinations (three modes, two branches of `AllowedFunctionNames`, two "leave it unset" paths). The Anthropic test asserts on the discriminated-union variant (`OfAuto` / `OfAny` / `OfTool` / `OfNone`) rather than the nested `Type` field because the SDK uses `shared/constant` single-value string types whose in-memory zero is `""` — the discriminator is injected during marshaling, and the variant pointer is what the marshaler keys off of.
+Each adapter has a table-driven test (`openai_test.go` / `anthropic_test.go`) covering the seven relevant combinations (three modes, two branches of `AllowedFunctionNames`, two "leave it unset" paths). The Anthropic test asserts on the discriminated-union variant (`OfAuto` / `OfAny` / `OfTool` / `OfNone`) rather than the nested `Type` field because the SDK uses `shared/constant` single-value string types whose in-memory zero is `""`: the discriminator is injected during marshaling, and the variant pointer is what the marshaler keys off of.
 
 ## LLM Adapters: empty tool payloads serialise to `{}`, never `null`
 
@@ -407,6 +409,6 @@ A tool with no parameters (e.g. `exit_loop`) leaves `genai.FunctionCall.Args` ni
 
 Because this is a provider wire-schema rule, it lives in the adapters (consumers must not have to scrub their `genai.Content`):
 
-- `genai/openai` and `genai/anthropic` both route `FunctionCall.Args` and `FunctionResponse.Response` through `common.MarshalToolPayload` (in the `genai/common` package), which performs the `null`/empty → `{}` normalisation once for both providers, propagates a genuine marshal error, and never mutates the input. Keeping it in one place is what guarantees tool_use and tool_result stay symmetric and the two adapters stay interchangeable (D5).
+- `genai/openai` and `genai/anthropic` both route `FunctionCall.Args` and `FunctionResponse.Response` through `common.MarshalToolPayload` (in the `genai/common` package), which performs the `null`/empty -> `{}` normalisation once for both providers, propagates a genuine marshal error, and never mutates the input. Keeping it in one place is what guarantees tool_use and tool_result stay symmetric and the two adapters stay interchangeable (D5).
 
 Coverage: `genai/common/payload_test.go` pins the helper's unit contract; each adapter's `tool_payload_test.go` pins the integration, including a canary that fails if a future change "fixes" the nil payload by mutating the shared input in place. Full rationale and the per-provider decision list are in [DECISIONS.md](./DECISIONS.md) (decision D1).

--- a/.agents/COMPACTION_TOKEN_THRESHOLD_STRATEGY.md
+++ b/.agents/COMPACTION_TOKEN_THRESHOLD_STRATEGY.md
@@ -9,7 +9,7 @@ How the threshold strategy decides when and how to compact a conversation.
 | 1. **Estimate tokens** | Calculate how many tokens the current conversation uses, including contents, system instruction, and tool definitions. If real token counts from the provider are available, a correction factor (`real / previous heuristic`) is applied. Otherwise, the `len/4` heuristic is multiplied by 2.5x | The heuristic alone underestimates by 2-3x on structured content (JSON, tool schemas). Tool definitions and InlineData (images) are now counted in the heuristic. |
 | 2. **Compare against threshold** | If estimated tokens < `window - buffer`, do nothing. Buffer = fixed 20k for windows >200k, 20% for smaller windows | The buffer leaves room for the LLM response and error margin |
 | 3. **Truncate for the summarizer** | If the conversation is huge, drop the oldest messages until it fits within 80% of the summarizer LLM's context window | Prevents the summarization call itself from blowing up |
-| 4. **Summarize everything** | Send the entire conversation to the LLM with a structured prompt. If the LLM call fails, fall back to a mechanical summary (first 200 chars of each message) | A summary is always produced — the bloated conversation is never passed through |
+| 4. **Summarize everything** | Send the entire conversation to the LLM with a structured prompt. If the LLM call fails, fall back to a mechanical summary (first 200 chars of each message) | A summary is always produced: the bloated conversation is never passed through |
 | 5. **Replace contents** | `req.Contents` becomes just 2 messages: `[summary]` + `[continuation instruction]` | Goes from ~140k tokens down to ~1-2k. The agent continues without asking the user to repeat anything |
 | 6. **Reset calibration** | Clear real token count and previous heuristic from session state | Prevents the pre-compaction correction factor (huge) from causing an infinite compaction loop |
 | 7. **Persist heuristic** | Save the heuristic of the final (compacted) request to session state | The next turn can compute a fresh correction factor |
@@ -62,7 +62,7 @@ After compaction:
 
 | File | What it contains |
 |------|-----------------|
-| `compaction_strategy_threshold.go` | The `Compact()` method — the flow described above |
+| `compaction_strategy_threshold.go` | The `Compact()` method: the flow described above |
 | `compaction_utils.go` | Token estimation, calibration, summarization, truncation, state helpers |
 | `contextguard.go` | `BeforeModelCallback` (calls Compact + persists heuristic), `AfterModelCallback` (persists real tokens), constants |
 | `compaction_strategy_multiturn_test.go` | 91 multi-turn session simulations testing the full ADK flow |
@@ -85,7 +85,7 @@ Read from `google.golang.org/adk@v0.4.0/internal/llminternal/base_flow.go`:
 Run() (line 97):
   for {
     runOneStep()
-    if lastEvent.IsFinalResponse() → break
+    if lastEvent.IsFinalResponse() -> break
   }
 
 runOneStep() (line 123):
@@ -101,14 +101,14 @@ runOneStep() (line 123):
   4. postprocess                                           // line 158
   5. handleFunctionCalls:                                   // line 191
      - For each FunctionCall in response:
-       - callTool() (BeforeToolCallback → tool.Run → AfterToolCallback)
+       - callTool() (BeforeToolCallback -> tool.Run -> AfterToolCallback)
      - All FunctionResponse parts merged into ONE event    // line 547
   6. Yield function response event                         // line 208
-  7. Back in Run(): IsFinalResponse()=false → LOOP
+  7. Back in Run(): IsFinalResponse()=false -> LOOP
 ```
 
 **Key invariants confirmed:**
-- Each `runOneStep` creates a FRESH `req` — no accumulation between iterations
+- Each `runOneStep` creates a FRESH `req`: no accumulation between iterations
 - `ContentsRequestProcessor` rebuilds `Contents` from session events every time
 - Parallel tool calls produce ONE model Content with multiple FunctionCall parts
 - Parallel tool responses are merged into ONE user Content with multiple FunctionResponse parts
@@ -137,7 +137,7 @@ func cloneContents(src []*genai.Content) []*genai.Content {
 
 #### 2. Parallel tool calls modeled correctly
 
-All tool calls within a turn are now placed in a single model Content with multiple `FunctionCall` parts, and all tool responses in a single user Content with multiple `FunctionResponse` parts — matching how ADK's `mergeParallelFunctionResponseEvents` works.
+All tool calls within a turn are now placed in a single model Content with multiple `FunctionCall` parts, and all tool responses in a single user Content with multiple `FunctionResponse` parts: matching how ADK's `mergeParallelFunctionResponseEvents` works.
 
 Before:
 ```
@@ -151,25 +151,25 @@ After:
 [user: FunctionResponse("tool_1"), FunctionResponse("tool_2")]
 ```
 
-This is significant because it changes the token estimation — fewer Content entries, same total chars.
+This is significant because it changes the token estimation: fewer Content entries, same total chars.
 
 #### 3. Sequential tool chains
 
 New `sequential: true` field on `turnConfig`. When enabled, each tool call is a separate `runOneStep` iteration:
 
 ```
-User message → runLLMStep("user-msg")
-  → model calls tool A → runLLMStep("tool-chain-0")
-  → model calls tool B → runLLMStep("tool-chain-1")
-  → model calls tool C → runLLMStep("tool-chain-2")
-  → model returns text → BREAK
+User message -> runLLMStep("user-msg")
+  -> model calls tool A -> runLLMStep("tool-chain-0")
+  -> model calls tool B -> runLLMStep("tool-chain-1")
+  -> model calls tool C -> runLLMStep("tool-chain-2")
+  -> model returns text -> BREAK
 ```
 
 This models the real ADK flow where a model chains tool calls sequentially. Each step triggers a full `BeforeModelCallback`, so `ContextGuard` can compact mid-chain.
 
 #### 4. Immutable session events
 
-The simulator no longer replaces `contents` after compaction. In real ADK, session events are append-only — `ContentsRequestProcessor` rebuilds from ALL events every time. The simulator now models this: `contents` is never modified by `beforeModel`, only appended to when new user/model/tool messages are added.
+The simulator no longer replaces `contents` after compaction. In real ADK, session events are append-only: `ContentsRequestProcessor` rebuilds from ALL events every time. The simulator now models this: `contents` is never modified by `beforeModel`, only appended to when new user/model/tool messages are added.
 
 #### 5. Variable model response size
 
@@ -177,7 +177,7 @@ New `responseSize` field on `turnConfig` allows tests to specify how large the m
 
 ### Test suite (91 tests total)
 
-#### Category 1: Stress tests (`TestStress_*`) — 42 tests
+#### Category 1: Stress tests (`TestStress_*`): 42 tests
 
 | Test | Window | Turns | Ratio | UsageMetadata | Tools |
 |------|--------|-------|-------|---------------|-------|
@@ -192,12 +192,12 @@ New `responseSize` field on `turnConfig` allows tests to specify how large the m
 | `200k_LargeSystemPrompt` | 200k | 20 | 2.0 | yes | 1/turn (5k), 50k system |
 | `200k_MassiveToolBurst` | 200k | 2 | 2.0 | yes | 15 parallel (50k each) |
 | `200k_RepeatedCompactions` | 200k | 60 | 2.0 | yes | every 2nd (30k+10k) |
-| `200k_LateUsageMetadata` | 200k | 5+20 | 2.0→2.5 | no→yes | 1/turn (5-10k) |
+| `200k_LateUsageMetadata` | 200k | 5+20 | 2.0->2.5 | no->yes | 1/turn (5-10k) |
 | `200k_100Turns_MixedWorkload` | 200k | 100 | 2.3 | yes | mixed (1k-50k) |
 | `200k_KubeAgent` | 200k | 20 | 2.5 | yes | kubectl_get_pods (15k) + describe (10k) + logs (25k) |
 | `200k_MixedDebugSession` | 200k | 25 | 2.2 | yes | prometheus (20k) + sql (15k) + http (500) + grep (8k) mixed |
 | `200k_PureToolStorm` | 200k | 30 | 2.0 | yes | 2/turn (5k each), minimal text |
-| `200k_CodingAgent` | 200k | 15 | 2.5 | yes | read_file (8k) → edit_file (2k) → run_tests (12k) sequential |
+| `200k_CodingAgent` | 200k | 15 | 2.5 | yes | read_file (8k) -> edit_file (2k) -> run_tests (12k) sequential |
 | `1M_NormalConversation` | 1M | 50 | 2.0 | yes | 1/turn (10k) |
 | `1M_HeavyTools` | 1M | 30 | 2.0 | yes | read_file (50k) + grep (20k) + tests (30k) |
 | `4k_NormalConversation` | 4k | 20 | 1.8 | yes | none |
@@ -217,14 +217,14 @@ New `responseSize` field on `turnConfig` allows tests to specify how large the m
 | `8k_KubeAgent` | 8k | 10 | 2.0 | yes | kubectl_get_pods (5k) + describe (3k) + logs (8k) |
 | `8k_MixedDebugSession` | 8k | 20 | 1.8 | yes | prometheus (3k) + sql (2k) + http (200) mixed |
 | `8k_PureToolStorm` | 8k | 20 | 1.8 | yes | 1/turn (2k), minimal text |
-| `8k_CodingAgent` | 8k | 10 | 2.0 | yes | read_file (3k) → edit_file (1k) → run_tests (4k) sequential |
+| `8k_CodingAgent` | 8k | 10 | 2.0 | yes | read_file (3k) -> edit_file (1k) -> run_tests (4k) sequential |
 | `200k_HeavyToolDefinitions` | 200k | 30 | 2.0 | yes | 2/turn (5k+8k), 20 MCP tool defs (2k schema each) |
 | `200k_InlineImages` | 200k | 15 | 2.0 | yes | none, 100KB image/turn |
 | `8k_HeavyToolDefinitions` | 8k | 20 | 2.0 | yes | 1/turn (1.5k), 10 MCP tool defs (1k schema each) |
 | `8k_InlineSmallImages` | 8k | 10 | 2.0 | yes | none, 10KB image/turn |
 | `CompactionNoInfiniteLoop` | 8k | 5 | 2.5 | yes | none, 12k system |
 
-#### Category 2: Brutal tests (`TestBrutal_*`) — 49 tests
+#### Category 2: Brutal tests (`TestBrutal_*`): 49 tests
 
 Extreme scenarios designed to break the compaction system:
 
@@ -261,11 +261,11 @@ Extreme scenarios designed to break the compaction system:
 | `200k_PureToolStorm_HugeResponses` | 200k | 20 | 2.0 | fetch (50k) + process (20k) per turn, minimal text |
 | `8k_PureToolStorm_50Turns` | 8k | 50 | 2.0 | 3k tool/turn, minimal text, 50 turns |
 | `200k_CodingAgent_DeepRefactor` | 200k | 25 | 2.5 | 6 sequential tools/turn (read+grep+edit+read+edit+tests), large outputs |
-| `8k_CodingAgent_NoUsageMetadata` | 8k | 15 | 2.0 | Sequential read→edit→tests, no calibration |
+| `8k_CodingAgent_NoUsageMetadata` | 8k | 15 | 2.0 | Sequential read->edit->tests, no calibration |
 | `4k_ToolResponseExceedsWindow` | 4k | 3 | 2.0 | Single 20k tool response (5× window) |
 | `4k_EveryTurnExceedsWindow` | 4k | 20 | 2.0 | 1k msg + 8k tool every turn |
 | `4k_KubeAgent` | 4k | 10 | 2.0 | kubectl pattern in tiny window |
-| `4k_CodingAgent` | 4k | 10 | 2.0 | Sequential read→edit→tests in tiny window |
+| `4k_CodingAgent` | 4k | 10 | 2.0 | Sequential read->edit->tests in tiny window |
 | `4k_MixedDebug` | 4k | 15 | 2.0 | prometheus + sql + http mixed in 4k |
 | `4k_PureToolStorm` | 4k | 20 | 2.0 | 2k tool/turn, minimal text in 4k |
 | `1M_KubeAgent_ExtremeLongevity` | 1M | 100 | 2.0 | kubectl (30k+20k+50k) per turn, 100 turns |
@@ -273,9 +273,9 @@ Extreme scenarios designed to break the compaction system:
 | `1M_NoUsageMetadata` | 1M | 40 | 2.5 | 45k tools/turn, no calibration, 1M window |
 | `200k_MagecProductionScenario` | 200k | 30 | 2.5 | 25 MCP tools + images + 2-4 tool calls/turn (exact production setup) |
 | `200k_MagecProductionScenario_NoUsageMetadata` | 200k | 20 | 2.5 | 20 MCP tools + images + no calibration |
-| `200k_SequentialEscalatingSizes` | 200k | 10 | 2.0 | 5 sequential tools escalating: 2k→5k→20k→40k→60k |
-| `8k_SequentialEscalatingSizes` | 8k | 10 | 2.0 | 4 sequential tools escalating: 500→1.5k→3k→5k |
-| `4k_SequentialEscalatingSizes` | 4k | 8 | 2.0 | 3 sequential tools escalating: 300→800→2k |
+| `200k_SequentialEscalatingSizes` | 200k | 10 | 2.0 | 5 sequential tools escalating: 2k->5k->20k->40k->60k |
+| `8k_SequentialEscalatingSizes` | 8k | 10 | 2.0 | 4 sequential tools escalating: 500->1.5k->3k->5k |
+| `4k_SequentialEscalatingSizes` | 4k | 8 | 2.0 | 3 sequential tools escalating: 300->800->2k |
 | `8k_SequentialToolChain` | 8k | 8 | 2.0 | 5 sequential tools (2k, 1.5k, 2.5k, 1k, 1.5k) |
 | `200k_SequentialToolChain_LargeResponses` | 200k | 5 | 2.0 | 5 sequential tools (40k, 20k, 30k, 15k, 5k) |
 | `8k_SequentialChain_NoUsageMetadata` | 8k | 10 | 2.0 | 3 sequential tools (1k, 800, 1.2k), no calibration |
@@ -293,15 +293,15 @@ Extreme scenarios designed to break the compaction system:
 Compaction had **zero effect** in production. ContextGuard compacted successfully on turn N, but on turn N+1 the full uncompacted context was back:
 
 ```
-tokens=228967 threshold=120000  → compaction completed, newTokenEstimate=8756
-tokens=231400 threshold=120000  → compaction completed, newTokenEstimate=8798
-tokens=228967 threshold=120000  → compaction completed, newTokenEstimate=8756
+tokens=228967 threshold=120000  -> compaction completed, newTokenEstimate=8756
+tokens=231400 threshold=120000  -> compaction completed, newTokenEstimate=8798
+tokens=228967 threshold=120000  -> compaction completed, newTokenEstimate=8756
 ... (every single turn, forever)
 ```
 
 ### Root cause: ADK's session events are immutable
 
-`ContentsRequestProcessor` reads from `ctx.Session().Events().All()` — the **full, immutable, append-only** event list. Session events are never deleted or modified. The processor rebuilds `req.Contents` from scratch every time.
+`ContentsRequestProcessor` reads from `ctx.Session().Events().All()`: the **full, immutable, append-only** event list. Session events are never deleted or modified. The processor rebuilds `req.Contents` from scratch every time.
 
 ContextGuard's `Compact()` rewrites `req.Contents` in memory, which affects the current LLM call. But those changes are **not persisted back to the session events**. On the next call, all events are loaded again and the compacted result is lost.
 
@@ -312,8 +312,8 @@ ContextGuard's `Compact()` rewrites `req.Contents` in memory, which affects the 
 ```
 Before (broken):
   req.Contents = [event1, event2, ..., event50]     ← loaded by ADK from all events
-  injectSummary → [SUMMARY, event1, event2, ..., event50]   ← WORSE than before
-  tokenCount → exceeds threshold → compacts AGAIN
+  injectSummary -> [SUMMARY, event1, event2, ..., event50]   ← WORSE than before
+  tokenCount -> exceeds threshold -> compacts AGAIN
 ```
 
 ### The fix: watermark-based event stripping
@@ -324,19 +324,19 @@ The `contentsAtCompaction` watermark (which already existed in the sliding windo
 After (fixed):
   req.Contents = [event1, event2, ..., event50, event51, event52]   ← all events
   watermark = 50 (saved at last compaction)
-  injectSummary → [SUMMARY, event51, event52]   ← old events stripped
-  tokenCount → below threshold → no compaction needed ✓
+  injectSummary -> [SUMMARY, event51, event52]   ← old events stripped
+  tokenCount -> below threshold -> no compaction needed ✓
 ```
 
 ### Changes
 
-**`compaction_utils.go`** — `injectSummary` now takes `contentsAtCompaction int`. When > 0 and <= len(req.Contents), it strips the first N entries and prepends the summary before the remaining new entries.
+**`compaction_utils.go`**: `injectSummary` now takes `contentsAtCompaction int`. When > 0 and <= len(req.Contents), it strips the first N entries and prepends the summary before the remaining new entries.
 
-**`compaction_strategy_threshold.go`** — Captures `totalSessionContents = len(req.Contents)` before any modification and calls `persistContentsAtCompaction(ctx, totalSessionContents)` after compaction.
+**`compaction_strategy_threshold.go`**: Captures `totalSessionContents = len(req.Contents)` before any modification and calls `persistContentsAtCompaction(ctx, totalSessionContents)` after compaction.
 
-**`compaction_strategy_sliding_window.go`** — Updated `injectSummary` call to pass `contentsAtLastCompaction`.
+**`compaction_strategy_sliding_window.go`**: Updated `injectSummary` call to pass `contentsAtLastCompaction`.
 
-**`compaction_strategy_multiturn_test.go`** — Simulator no longer replaces `contents` after compaction (models immutable session events). Loop detection simplified to: compaction is a "loop" only if output >= input.
+**`compaction_strategy_multiturn_test.go`**: Simulator no longer replaces `contents` after compaction (models immutable session events). Loop detection simplified to: compaction is a "loop" only if output >= input.
 
 ### Session state keys
 
@@ -361,14 +361,14 @@ The simulator treated `contents` as mutable state that got replaced after compac
 
 ### The bug
 
-ContextGuard never fired compaction on a 200k context window with `claude-sonnet-4-6`. Anthropic returned `400 Bad Request: prompt is too long: 200819 tokens` — the context was exceeded without any compaction attempt.
+ContextGuard never fired compaction on a 200k context window with `claude-sonnet-4-6`. Anthropic returned `400 Bad Request: prompt is too long: 200819 tokens`: the context was exceeded without any compaction attempt.
 
 ```
 time=2026-02-28T13:52:44Z level=ERROR msg="prompt is too long: 200819 tokens"
 time=2026-02-28T13:55:11Z level=ERROR msg="prompt is too long: 200911 tokens"
 ```
 
-No `ContextGuard [threshold]: threshold exceeded` log appeared — `tokenCount()` never reached the threshold.
+No `ContextGuard [threshold]: threshold exceeded` log appeared: `tokenCount()` never reached the threshold.
 
 ### Root cause: three blind spots in token estimation
 
@@ -376,13 +376,13 @@ No `ContextGuard [threshold]: threshold exceeded` log appeared — `tokenCount()
 
 **2. InlineData not counted.** `estimatePartTokens()` handled `Text`, `FunctionCall`, and `FunctionResponse` parts, but `InlineData` (arbitrary binary blobs: images, PDFs, audio, video) was counted as 0 tokens. A single base64-encoded image can be tens of thousands of tokens.
 
-**3. Buffer boundary off-by-one.** `computeBuffer()` used `contextWindow > 200000` — for a 200k window exactly, this was `false`, so the 20% ratio applied instead of the fixed 20k buffer. Result: buffer = 40k, threshold = 160k instead of the intended buffer = 20k, threshold = 180k. Not the primary cause, but it moved the threshold 20k lower than designed.
+**3. Buffer boundary off-by-one.** `computeBuffer()` used `contextWindow > 200000`: for a 200k window exactly, this was `false`, so the 20% ratio applied instead of the fixed 20k buffer. Result: buffer = 40k, threshold = 160k instead of the intended buffer = 20k, threshold = 180k. Not the primary cause, but it moved the threshold 20k lower than designed.
 
 **4. Default correction factor too conservative.** `defaultHeuristicCorrectionFactor` was 2.0, but real-world structured content (JSON tool schemas, markdown, non-ASCII) typically underestimates by 2-3x. With tool definitions invisible and a 2.0 factor, the heuristic couldn't reach the threshold even with calibration capped at 5x.
 
 ### Why calibration couldn't save it
 
-In the production session, the heuristic saw ~24k tokens but Anthropic counted ~200k — a ratio of **8.3x**. The calibration system bridges this gap using `correction = realTokens / lastHeuristic`, but:
+In the production session, the heuristic saw ~24k tokens but Anthropic counted ~200k: a ratio of **8.3x**. The calibration system bridges this gap using `correction = realTokens / lastHeuristic`, but:
 
 - The correction factor is capped at 5.0x to prevent anomalous turns from distorting future estimates
 - 24k × 5.0 = 120k, still below the 160k threshold (with the old buffer)
@@ -393,7 +393,7 @@ The fundamental problem: when the heuristic is missing entire categories of toke
 
 ### The fixes
 
-**`compaction_utils.go` — `estimateToolTokens()` (new function)**
+**`compaction_utils.go`: `estimateToolTokens()` (new function)**
 
 ```go
 func estimateToolTokens(tools []*genai.Tool) int {
@@ -403,7 +403,7 @@ func estimateToolTokens(tools []*genai.Tool) int {
 
 `estimateTokens()` now calls `estimateToolTokens(req.Config.Tools)` alongside contents and system instruction.
 
-**`compaction_utils.go` — `estimatePartTokens()` now counts InlineData**
+**`compaction_utils.go`: `estimatePartTokens()` now counts InlineData**
 
 ```go
 if part.InlineData != nil {
@@ -412,9 +412,9 @@ if part.InlineData != nil {
 }
 ```
 
-`InlineData` is a generic `*genai.Blob` carrying raw bytes + MIME type — it covers images, PDFs, audio, video, and any other binary content. The fix counts all of them.
+`InlineData` is a generic `*genai.Blob` carrying raw bytes + MIME type: it covers images, PDFs, audio, video, and any other binary content. The fix counts all of them.
 
-**`compaction_utils.go` — `computeBuffer()` boundary fix**
+**`compaction_utils.go`: `computeBuffer()` boundary fix**
 
 ```go
 // Before: contextWindow > largeContextWindowThreshold  (200k > 200k = false)
@@ -423,7 +423,7 @@ if part.InlineData != nil {
 
 200k windows now get the fixed 20k buffer (threshold = 180k) instead of the 20% buffer of 40k (threshold = 160k).
 
-**`contextguard.go` — `defaultHeuristicCorrectionFactor` raised to 2.5**
+**`contextguard.go`: `defaultHeuristicCorrectionFactor` raised to 2.5**
 
 From 2.0 to 2.5. Accounts for the typical 2-3x underestimation of `len/4` on structured content, plus the overhead from tool definitions and system prompts that tokenize denser than plain text. Conservative enough to avoid premature compaction, aggressive enough to catch real overflow before calibration data is available.
 
@@ -431,13 +431,13 @@ From 2.0 to 2.5. Accounts for the typical 2-3x underestimation of `len/4` on str
 
 | Test | What it validates |
 |------|-------------------|
-| `TestEstimateToolTokens_Nil` | nil tools → 0 tokens |
-| `TestEstimateToolTokens_WithDeclarations` | 2 tools with `ParametersJsonSchema` → >50 tokens |
+| `TestEstimateToolTokens_Nil` | nil tools -> 0 tokens |
+| `TestEstimateToolTokens_WithDeclarations` | 2 tools with `ParametersJsonSchema` -> >50 tokens |
 | `TestEstimateToolTokens_WithParametersSchema` | Tools using `*genai.Schema` instead of raw JSON |
 | `TestEstimateTokens_IncludesTools` | `estimateTokens(req with tools) > estimateTokens(req without tools)` |
-| `TestEstimatePartTokens_InlineData` | 10k bytes of inline data → counted at ≥ `len/4` tokens |
-| `TestComputeBuffer/exactly_at_threshold` | 200k window → 20k buffer (was 40k) |
+| `TestEstimatePartTokens_InlineData` | 10k bytes of inline data -> counted at ≥ `len/4` tokens |
+| `TestComputeBuffer/exactly_at_threshold` | 200k window -> 20k buffer (was 40k) |
 
 ### Why `WithMaxTokens(180000)` worked as a workaround
 
-Setting `maxTokens = 180000` bypasses the registry lookup. `computeBuffer(180000)` → `180000 < 200000` → buffer = 36k → threshold = 144k. With `realTokens` from `afterModel` persisted at ~180k (previous turn), `tokenCount()` returned `max(180000, calibrated) ≥ 180000 > 144000` → compaction fired. The lower threshold made it possible for the stale `realTokens` alone to exceed it, sidestepping the heuristic blind spots entirely.
+Setting `maxTokens = 180000` bypasses the registry lookup. `computeBuffer(180000)` -> `180000 < 200000` -> buffer = 36k -> threshold = 144k. With `realTokens` from `afterModel` persisted at ~180k (previous turn), `tokenCount()` returned `max(180000, calibrated) ≥ 180000 > 144000` -> compaction fired. The lower threshold made it possible for the stale `realTokens` alone to exceed it, sidestepping the heuristic blind spots entirely.

--- a/.agents/DECISIONS.md
+++ b/.agents/DECISIONS.md
@@ -134,7 +134,7 @@ equivalent, working outputs.
 - **What is allowed to differ:** constructor/config surface, caching, billing/
   auth transport, provider-only features (reasoning blocks). These are opt-in at
   construction time and don't change the `model.LLM` runtime contract.
-- **Why:** consumers (baifo, Magec, …) pick a provider by config and expect the
+- **Why:** consumers (baifo, Magec, ...) pick a provider by config and expect the
   agent to "just work". A divergence where "this provider does X and the other
   does Y and that's why it breaks" is a bug in *this* library, not the
   consumer's problem. Every cross-provider decision above (D1-D4) exists to hold
@@ -230,13 +230,13 @@ OpenAI's Chat Completions API only emits a final usage chunk on the SSE stream
 when the caller opts in via `stream_options.include_usage`. Without it, the
 `ChatCompletionAccumulator`'s `Usage` stays zero, and `buildStreamFinalResponse`
 already reads that accumulator (`convertUsageMetadata(acc.Usage)`) into the
-terminal `LLMResponse`'s `UsageMetadata` — so the plumbing was there, but the
+terminal `LLMResponse`'s `UsageMetadata`: so the plumbing was there, but the
 opt-in was missing.
 
 - **Decision:** `generateStream` sets `params.StreamOptions.IncludeUsage =
   param.NewOpt(true)` before `NewStreaming`. The final `LLMResponse` on the
   streaming path now carries populated `UsageMetadata`, matching the non-
-  streaming path (`generate` → `convertResponse`).
+  streaming path (`generate` -> `convertResponse`).
 - **Why:** consumers that price token spend (Langfuse, billing dashboards)
   need usage on **every** turn, not just the non-streaming ones. Forcing
   callers to pick between streaming UX and usage accounting turned the
@@ -250,7 +250,7 @@ opt-in was missing.
   usage block. No behaviour change for those.
 - **Interrupted streams:** OpenAI's docs note that a broken stream may drop
   the terminal usage chunk. That surfaces as an accumulator with zero usage
-  and O6 drops it — consistent with the pre-change behaviour on those failed
+  and O6 drops it: consistent with the pre-change behaviour on those failed
   turns.
 - **Tests:** `wire_test.go::TestWireBody_StreamRequestsUsage` fires one
   streaming request through the wire-capture fixture and asserts the JSON

--- a/.agents/INVESTIGATION_RESULTS.md
+++ b/.agents/INVESTIGATION_RESULTS.md
@@ -6,18 +6,18 @@
 
 ---
 
-## Part 1: Original approach — split with recent tail (historical)
+## Part 1: Original approach: split with recent tail (historical)
 
-> **Note**: This section documents the original behaviour before Proposal 5. The threshold strategy no longer keeps a recent tail — it always summarizes everything. These results explain *why* the recent tail approach was abandoned.
+> **Note**: This section documents the original behaviour before Proposal 5. The threshold strategy no longer keeps a recent tail: it always summarizes everything. These results explain *why* the recent tail approach was abandoned.
 
 ### Retry Rounds vs `kube-3rounds / 8k ctx`
 
 | Scenario | Attempts | Tokens Before | Tokens After | Reduction | Contents | Fits? |
 |---|---|---|---|---|---|---|
-| kube-3r/8k/attempts=1 | 1 | 24,126 | 8,068 | 66.6% | 24→9 | NO |
-| kube-3r/8k/attempts=3 | 3 | 24,126 | 8,068 | 66.6% | 24→9 | NO |
-| kube-3r/8k/attempts=10 | 10 | 24,126 | 8,068 | 66.6% | 24→9 | NO |
-| kube-3r/8k/attempts=20 | 20 | 24,126 | 8,068 | 66.6% | 24→9 | NO |
+| kube-3r/8k/attempts=1 | 1 | 24,126 | 8,068 | 66.6% | 24->9 | NO |
+| kube-3r/8k/attempts=3 | 3 | 24,126 | 8,068 | 66.6% | 24->9 | NO |
+| kube-3r/8k/attempts=10 | 10 | 24,126 | 8,068 | 66.6% | 24->9 | NO |
+| kube-3r/8k/attempts=20 | 20 | 24,126 | 8,068 | 66.6% | 24->9 | NO |
 
 **Conclusion**: More retry rounds provided zero benefit. The 9 remaining recent messages (~8k tokens from 3 tool_call/tool_response pairs) were untouched by compaction. This was the fundamental flaw: the recent tail is irreducible.
 
@@ -39,12 +39,12 @@
 
 The original design kept ~20% of the context window as verbatim recent messages. This meant:
 1. A single large tool response in the recent window could exceed the budget alone.
-2. Retry loops only re-compacted already-compacted older content — the recent window was never touched.
+2. Retry loops only re-compacted already-compacted older content: the recent window was never touched.
 3. The system failed deterministically for any context window where one round of tool responses exceeded the threshold.
 
 ---
 
-## Part 2: Current approach — full summary (Crush-style)
+## Part 2: Current approach: full summary (Crush-style)
 
 The threshold strategy now summarizes the **entire** conversation. After compaction, `req.Contents` is exactly:
 
@@ -67,11 +67,11 @@ Post-compaction result is always `summary (~maxOutputTokens) + continuation (~10
 
 ### Summarization input is safe too
 
-The summarization prompt renders tool results as `[tool X returned a result]` — raw payloads are not included. So even a conversation with 500k of JSON tool responses produces a summarization input of manageable size (tool calls listed as one-liners).
+The summarization prompt renders tool results as `[tool X returned a result]`: raw payloads are not included. So even a conversation with 500k of JSON tool responses produces a summarization input of manageable size (tool calls listed as one-liners).
 
 ---
 
-## Part 3: Timing gap — calibrated heuristic
+## Part 3: Timing gap: calibrated heuristic
 
 ### The problem
 
@@ -79,11 +79,11 @@ ContextGuard uses `BeforeModelCallback` (before the LLM call) to check tokens, b
 
 ```
 Step N:
-  BeforeModelCallback → check tokens → LLM call → AfterModelCallback (persist PromptTokenCount)
-  → Tool executes → result appended to session
+  BeforeModelCallback -> check tokens -> LLM call -> AfterModelCallback (persist PromptTokenCount)
+  -> Tool executes -> result appended to session
 
 Step N+1:
-  preprocess (builds req with new tool results) → BeforeModelCallback → reads stale PromptTokenCount from N
+  preprocess (builds req with new tool results) -> BeforeModelCallback -> reads stale PromptTokenCount from N
 ```
 
 If the tool returned a massive response, `req` at step N+1 is larger than what was measured at step N. Using the stale `PromptTokenCount` directly would miss the growth.
@@ -109,9 +109,9 @@ return max(real, calibrated)
 ```
 
 **Why this works**:
-- `currentHeuristic` tracks growth (tool results added → more text → higher heuristic).
+- `currentHeuristic` tracks growth (tool results added -> more text -> higher heuristic).
 - `correction` translates heuristic tokens into real tokens using the last known ratio.
-- `max(real, calibrated)` ensures we never undercount — if the request didn't grow, `real` dominates; if it grew, `calibrated` dominates.
+- `max(real, calibrated)` ensures we never undercount: if the request didn't grow, `real` dominates; if it grew, `calibrated` dominates.
 - The correction factor is floored at 1.0 to prevent the calibrated value from being smaller than the raw heuristic.
 - If no real tokens exist (first turn), a conservative default factor of 2.5 is applied.
 
@@ -150,7 +150,7 @@ BeforeModelCallback (step N)
 │   ├── correction = max(1.0, real / lastHeuristic)
 │   ├── calibrated = currentHeuristic × correction
 │   └── return max(real, calibrated)
-├── if totalTokens < threshold → pass through
+├── if totalTokens < threshold -> pass through
 ├── if totalTokens ≥ threshold:
 │   ├── summarize(entire conversation)               ← LLM call with structured prompt
 │   ├── replaceSummary(req, summary, nil)             ← req = [summary]
@@ -158,12 +158,12 @@ BeforeModelCallback (step N)
 │   └── persistSummary(ctx, summary, totalTokens)
 └── persistLastHeuristic(ctx, estimateTokens(req))    ← for next step's calibration
 
-LLM call (step N) → response with PromptTokenCount
+LLM call (step N) -> response with PromptTokenCount
 
 AfterModelCallback (step N)
 └── persistRealTokens(ctx, PromptTokenCount)          ← for next step's calibration
 
-Tool execution → results appended to session → loop back to step N+1
+Tool execution -> results appended to session -> loop back to step N+1
 ```
 
 ### Key design decisions
@@ -176,18 +176,18 @@ Tool execution → results appended to session → loop back to step N+1
 | Calibrated heuristic instead of raw `max(real, heuristic)` | Raw heuristic underestimates by 2-3× for structured content. The correction factor from the previous call bridges this gap. |
 | Correction factor floored at 1.0 | Prevents the heuristic from being *reduced* when real tokens are lower (e.g., after compaction). |
 | Correction factor capped at 5.0 | Prevents a single anomalous turn (JSON-heavy tool schemas) from producing a disproportionate correction that persists. |
-| Default factor 2.5 for first turn | Conservative — triggers compaction slightly early rather than risking overflow on the very first turn without calibration data. Accounts for tool definitions and structured content overhead not fully captured by len/4. |
+| Default factor 2.5 for first turn | Conservative: triggers compaction slightly early rather than risking overflow on the very first turn without calibration data. Accounts for tool definitions and structured content overhead not fully captured by len/4. |
 | Continuation message includes original user request | Prevents the agent from asking the user to repeat themselves after compaction. |
 | Todo preservation in summary prompt | Maintains task tracking state across compaction boundaries. |
 | Truncate conversation before summarization | Prevents the summarization prompt itself from exceeding the summarizer LLM's context window. |
 | Fallback summary on LLM failure | If summarization fails, a mechanical summary (first 200 chars of each message) is used instead of passing through the bloated request. |
 | Count tool definitions in heuristic | Tool declarations (name, description, JSON schemas) are sent with every request. Without counting them, the heuristic can underestimate by 8x+ for tool-heavy agents. |
 | Count InlineData in heuristic | `InlineData` is a generic `*genai.Blob` (images, PDFs, audio, video). A single base64-encoded image can be tens of thousands of tokens invisible to the old heuristic. |
-| Buffer boundary `>=` not `>` | 200k windows should use the fixed 20k buffer. `>` excluded 200k exactly, applying 20% (40k) instead — an unintended 20k threshold reduction. |
+| Buffer boundary `>=` not `>` | 200k windows should use the fixed 20k buffer. `>` excluded 200k exactly, applying 20% (40k) instead: an unintended 20k threshold reduction. |
 
 ---
 
-## Part 4: Hardening — production-readiness improvements
+## Part 4: Hardening: production-readiness improvements
 
 ### Problem: three failure modes identified in production testing
 
@@ -237,7 +237,7 @@ if err != nil {
 }
 ```
 
-`buildFallbackSummary()` concatenates the first 200 chars of each message — mechanical but guaranteed to succeed and be small. The session continues with degraded summary quality rather than crashing.
+`buildFallbackSummary()` concatenates the first 200 chars of each message: mechanical but guaranteed to succeed and be small. The session continues with degraded summary quality rather than crashing.
 
 ### Stress test validation
 

--- a/.agents/LANGFUSE_PLUGIN.md
+++ b/.agents/LANGFUSE_PLUGIN.md
@@ -36,11 +36,11 @@ Wraps the real OTLP `SpanExporter`. At export time, for every span named `genera
 1. Looks up the span's parent ID (which is the `invoke_agent` span ID)
 2. Pops the oldest pending `llmCall` for that ID (FIFO queue)
 3. Injects extra attributes into the span:
-   - `gcp.vertex.agent.llm_request` — full serialised prompt
-   - `gcp.vertex.agent.llm_response` — model output text
-   - `gen_ai.request.model` — model identifier
-   - `gen_ai.usage.input_tokens` — prompt token count
-   - `gen_ai.usage.output_tokens` — completion token count
+   - `gcp.vertex.agent.llm_request`: full serialised prompt
+   - `gcp.vertex.agent.llm_response`: model output text
+   - `gen_ai.request.model`: model identifier
+   - `gen_ai.usage.input_tokens`: prompt token count
+   - `gen_ai.usage.output_tokens`: completion token count
 
 The injection is done via `enrichedSpan`, a thin wrapper around `sdktrace.ReadOnlySpan` that appends extra attributes without mutating the original span.
 
@@ -67,12 +67,12 @@ ADK plugin callbacks see the `invoke_agent` span in their context, but the `gene
                     │         │                    │
                     │         ▼                    │
                     │  enrichingExporter           │
-                    │  (matches parent ID →        │
-                    │   pops pending llmCall →     │
+                    │  (matches parent ID ->        │
+                    │   pops pending llmCall ->     │
                     │   injects attributes)        │
                     │         │                    │
                     │         ▼                    │
-                    │  OTLP HTTP → Langfuse        │
+                    │  OTLP HTTP -> Langfuse        │
                     └─────────────────────────────┘
 ```
 
@@ -84,15 +84,15 @@ The plugin is safe for all ADK agent topologies:
 |---|---|
 | Single agent | Keys are `invocationID` (branch is empty) |
 | Sequential delegation (`transfer_to_agent`) | Each agent gets its own `invoke_agent` span with a unique span ID. The stack tracks nesting. |
-| `SequentialAgent` / `LoopAgent` | Same as delegation — sequential execution, stack-based tracking |
+| `SequentialAgent` / `LoopAgent` | Same as delegation: sequential execution, stack-based tracking |
 | `ParallelAgent` | Each sub-agent gets a distinct `Branch()` value. The `branchKey` function combines `invocationID + ":" + branch` so concurrent sub-agents never collide. |
 
 ## Concurrency
 
 All mutable state lives in `spanEnricher` behind a single `sync.Mutex`. The state is request-scoped and ephemeral:
 
-- `agentSpans`: per-branch stack of active `invoke_agent` spans — pushed in `beforeAgent`, popped in `afterAgent`
-- `pending`: FIFO queue of `llmCall` per span ID — enqueued in `beforeModel`, updated in `afterModel`, dequeued in `ExportSpans`
+- `agentSpans`: per-branch stack of active `invoke_agent` spans: pushed in `beforeAgent`, popped in `afterAgent`
+- `pending`: FIFO queue of `llmCall` per span ID: enqueued in `beforeModel`, updated in `afterModel`, dequeued in `ExportSpans`
 
 Each HTTP request's lifecycle is handled entirely by one server instance (spans don't hop across replicas), so this is safe for multi-replica deployments.
 
@@ -214,9 +214,9 @@ Langfuse calculates costs when it receives `gen_ai.usage.input_tokens` and `gen_
 
 The plugin adds these direct dependencies beyond what adk-utils-go already has:
 
-- `go.opentelemetry.io/otel` — OTel API (attributes, trace)
-- `go.opentelemetry.io/otel/sdk` — OTel SDK (TracerProvider, BatchSpanProcessor, ReadOnlySpan)
-- `go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp` — OTLP/HTTP exporter
-- `go.opentelemetry.io/otel/semconv/v1.36.0` — semantic conventions (service.name, deployment.environment)
+- `go.opentelemetry.io/otel`: OTel API (attributes, trace)
+- `go.opentelemetry.io/otel/sdk`: OTel SDK (TracerProvider, BatchSpanProcessor, ReadOnlySpan)
+- `go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp`: OTLP/HTTP exporter
+- `go.opentelemetry.io/otel/semconv/v1.36.0`: semantic conventions (service.name, deployment.environment)
 
 All of these were already indirect dependencies via ADK; the plugin promotes them to direct.

--- a/.agents/STYLE.md
+++ b/.agents/STYLE.md
@@ -1,0 +1,111 @@
+# STYLE.md
+
+How to write text in this repository: code comments, the README, and the
+docs in `.agents/`. Read this before writing or editing any of them. These
+rules exist so the repo reads like a person wrote it, and so nobody has to
+re-litigate them in review.
+
+## The one rule that matters
+
+Write for the reader of each text.
+
+This is living documentation, not a changelog. It states the rules that are
+current now; it does not narrate how they evolved. When two entries conflict,
+the most recent decision wins, and the older text gets rewritten or deleted,
+never annotated with "previously we did X". The same applies to every doc in
+this repo: if you find prose telling a story about what used to happen, fix
+the prose to state what is true now.
+
+- A **code comment** is read by a maintainer who is already inside the
+  code. It states a short, objective fact: what the function does, or why
+  it does it that way. It is not a changelog, not a blog post, not a
+  launch announcement.
+- The **README** is read by a human deciding whether to use the library.
+  Write like a person talking to that person.
+- The **`.agents/` docs** are read by agents (and humans) working on the
+  repo. Orient them: what exists, what is deliberate, what not to break.
+
+If a sentence would sound at home in a press release, it does not belong
+in any of the three.
+
+## Hard rules (enforced in review)
+
+1. **No typographic Unicode in prose.** No em-dashes (`—`), en-dashes
+   (`–`), curly quotes (`'` `'` `"` `"`), ellipsis character (`…`), or
+   arrows (`→`) in comments, docs, commit messages, PR bodies, or tag
+   messages. Use commas, colons, semicolons, parentheses, `...`, and a
+   plain ASCII hyphen for ranges (`D1-D5`, `v1.19.0 -> v1.61.0`).
+   Diagrams (ASCII art in docs) may keep box-drawing characters: a
+   diagram is not prose.
+
+2. **No references to `DECISIONS.md` entries outside `.agents/`.** IDs
+   like `O8`, `A11`, `D5` exist for people reading the decisions doc.
+   They never appear in code comments, commit messages, PR bodies, or
+   tag messages. If a comment needs the rationale, state the rationale
+   in one line instead of pointing at an ID.
+
+3. **Name components in words, not paths.** Write "the OpenAI adapter",
+   "the Langfuse plugin", "the Redis session service". Do not write
+   `genai/openai` or `plugin/langfuse` in prose aimed at a reader;
+   paths are for technical context (file headers, test names).
+
+4. **Fail-loud over silent, and say so when relevant.** If a function
+   returns an error where it used to drop something silently, that is
+   worth one line. It is the kind of fact a maintainer needs.
+
+## Code comments
+
+A code comment answers one of two questions, in as few lines as possible:
+
+- **What** does this do, when the name alone is not enough.
+- **Why** this way, when the choice is not obvious from the code.
+
+Guidelines:
+
+- **Short.** If a comment needs nine lines, the problem is the comment,
+  not the reader. Most functions need zero to four lines.
+- **Objective.** State what is true now. Do not narrate history
+  ("previously this dropped X") or the journey ("after trying Y we
+  settled on Z"): that belongs in commit messages and `DECISIONS.md`.
+- **No marketing.** Banned vocabulary in code comments includes
+  "flagship", "natural", "elegant", "seamless", "robust", and any
+  sentence built around an em-dash to sound dramatic.
+- **References are rare.** A link or a doc citation is justified only
+  when the behaviour implements an external contract the reader cannot
+  be expected to know (an API quirk, a provider's documented rule).
+  One pointer, not a bibliography.
+
+Example, from this repo:
+
+```go
+// convertFileDataToBlock maps a FileData part to an image block with a URL
+// source; the URI goes through verbatim, nothing is downloaded. Images only:
+// other media types need uploaded bytes (InlineData). Plain http is allowed
+// for gateways on Config.BaseURL; anthropic.com enforces https itself.
+```
+
+Four lines, states the contract, keeps the one non-obvious why. That is the
+bar.
+
+## README
+
+- Write for a human evaluating the library. Short sentences, plain words.
+- Feature lists say what the thing does, not how impressive it is.
+- Examples should be copy-pasteable and boring. Boring is a compliment.
+
+## `.agents/` docs
+
+- These orient the next worker. Lead with what exists and what is
+  deliberate, so nobody "fixes" a load-bearing behaviour back into a bug.
+- Referencing decision IDs (`O8`, `A11`, ...) is fine here, and only here.
+- Keep the same no-Unicode and no-marketing rules as everywhere else.
+
+## Commit, PR, and tag messages
+
+- Same hard rules: no typographic Unicode, no decision IDs, component
+  names in words.
+- Tag messages: what changed, per component, plus a behaviour note if
+  observable behaviour changes. Short. The audience is someone deciding
+  whether to upgrade.
+- PR bodies stand alone: do not cite other PRs or re-argue merged work
+  unless there is a real dependency.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repository provides production-ready implementations for:
 - **Memory Tools**: Toolsets for agent-controlled memory operations
 - **Artifact Storage**: Filesystem-based artifact persistence with versioning
 - **Context Guard**: Automatic context window management with LLM-powered summarization
-- **Langfuse**: Observability plugin — traces every LLM call to [Langfuse](https://langfuse.com) with full prompt/response payloads and token usage
+- **Langfuse**: Observability plugin: traces every LLM call to [Langfuse](https://langfuse.com) with full prompt/response payloads and token usage
 
 ## Structure
 
@@ -277,11 +277,11 @@ ctx = langfuse.WithTraceMetadata(ctx, map[string]string{"tenant": "acme"})
 
 | Field | Required | Default | Description |
 |---|---|---|---|
-| `PublicKey` | Yes | — | Langfuse project public key (Basic Auth user) |
-| `SecretKey` | Yes | — | Langfuse project secret key (Basic Auth pass) |
+| `PublicKey` | Yes |: | Langfuse project public key (Basic Auth user) |
+| `SecretKey` | Yes |: | Langfuse project secret key (Basic Auth pass) |
 | `Host` | No | `https://cloud.langfuse.com` | Langfuse server URL |
-| `Environment` | No | — | Deployment environment tag |
-| `Release` | No | — | Application version tag |
+| `Environment` | No |: | Deployment environment tag |
+| `Release` | No |: | Application version tag |
 | `ServiceName` | No | `langfuse-adk` | OTel `service.name` resource attribute |
 | `Insecure` | No | `false` | Disable TLS for the OTLP/HTTP exporter (for self-hosted plain-HTTP instances) |
 
@@ -289,7 +289,7 @@ Use `cfg.IsEnabled()` to conditionally skip setup when credentials are absent.
 
 ## Context Guard Plugin
 
-Automatic context window management that prevents conversations from exceeding the LLM's token limit. It works as an ADK `BeforeModelCallback` plugin — before every LLM call, it checks whether the conversation is approaching the limit and summarizes older messages to make room.
+Automatic context window management that prevents conversations from exceeding the LLM's token limit. It works as an ADK `BeforeModelCallback` plugin: before every LLM call, it checks whether the conversation is approaching the limit and summarizes older messages to make room.
 
 ### Strategies
 
@@ -300,15 +300,13 @@ Automatic context window management that prevents conversations from exceeding t
 
 ### Setup
 
-The plugin requires a `ModelRegistry` to look up context window sizes. A built-in `CrushRegistry` is provided that fetches model metadata from [Crush's provider.json](https://raw.githubusercontent.com/charmbracelet/crush/main/internal/agent/hyper/provider.json) and refreshes every 6 hours:
+The plugin requires a `ModelRegistry` to look up context window sizes. The built-in `CrushRegistry` ships catwalk's embedded model database, compiled into the binary: no network calls and no lifecycle to manage.
 
 ```go
 import "github.com/achetronic/adk-utils-go/plugin/contextguard"
 
-// 1. Start the registry (built-in, fetches from Crush)
+// 1. Create the registry (built-in, embedded model database)
 registry := contextguard.NewCrushRegistry()
-registry.Start(ctx)
-defer registry.Stop()
 
 // 2. Create the guard and add agents
 guard := contextguard.New(registry)
@@ -326,20 +324,20 @@ Per-agent options are available via functional options:
 ```go
 guard := contextguard.New(registry)
 
-// Threshold strategy (default) — summarizes when tokens approach the limit
+// Threshold strategy (default): summarizes when tokens approach the limit
 guard.Add("assistant", llmModel)
 
-// Sliding window — summarizes after N turns regardless of token count
+// Sliding window: summarizes after N turns regardless of token count
 guard.Add("researcher", llmResearcher, contextguard.WithSlidingWindow(30))
 
-// Manual context window override — bypasses the registry for this agent
+// Manual context window override: bypasses the registry for this agent
 guard.Add("writer", llmWriter, contextguard.WithMaxTokens(1_000_000))
 
-// Custom compaction retry limit (default: 3) — applies to both strategies
+// Custom compaction retry limit (default: 3): applies to both strategies
 guard.Add("analyst", llmAnalyst, contextguard.WithMaxCompactionAttempts(5))
 ```
 
-Multi-agent setup is the same API — just call `Add` multiple times:
+Multi-agent setup is the same API: just call `Add` multiple times:
 
 ```go
 guard := contextguard.New(registry)

--- a/examples/context-guard/main.go
+++ b/examples/context-guard/main.go
@@ -5,11 +5,11 @@
 //
 // This example shows the three ways to configure the ContextGuard plugin:
 //
-//  1. CrushRegistry — automatic context window detection from Crush's
-//     provider.json (refreshes every 6h, zero config).
-//  2. WithMaxTokens — manual context window override, useful when using
+//  1. CrushRegistry - automatic context window detection from catwalk's
+//     embedded model database (compiled into the binary, zero config).
+//  2. WithMaxTokens - manual context window override, useful when using
 //     beta features like Anthropic's 1M context window.
-//  3. WithSlidingWindow — turn-count-based compaction instead of
+//  3. WithSlidingWindow - turn-count-based compaction instead of
 //     token-threshold-based.
 //
 // The example uses the CrushRegistry with the threshold strategy by
@@ -51,7 +51,7 @@ func main() {
 
 	modelName := getEnvOrDefault("MODEL_NAME", "claude-sonnet-4-5-20250929")
 
-	// 1. Create the model registry — uses catwalk's embedded database,
+	// 1. Create the model registry - uses catwalk's embedded database,
 	//    no network calls needed.
 	registry := contextguard.NewCrushRegistry()
 
@@ -74,7 +74,7 @@ func main() {
 		log.Fatalf("Failed to create agent: %v", err)
 	}
 
-	// 4. Configure ContextGuard — pick strategy based on env vars
+	// 4. Configure ContextGuard - pick strategy based on env vars
 	guard := contextguard.New(registry)
 
 	strategy := getEnvOrDefault("STRATEGY", "threshold")

--- a/genai/anthropic/anthropic.go
+++ b/genai/anthropic/anthropic.go
@@ -408,18 +408,18 @@ func (m *Model) buildMessageParams(req *model.LLMRequest) (anthropic.MessageNewP
 			params.Tools = tools
 		}
 
-		// ToolConfig → tool_choice
+		// ToolConfig -> tool_choice
 		//
 		// Maps genai.FunctionCallingConfig.Mode to Anthropic's tool_choice:
-		//   ModeAuto → {type: "auto"} (default behaviour; model may or may not call a tool)
-		//   ModeAny  → {type: "any"}  (model MUST call a tool; use for agentic loops
+		//   ModeAuto -> {type: "auto"} (default behaviour; model may or may not call a tool)
+		//   ModeAny  -> {type: "any"}  (model MUST call a tool; use for agentic loops
 		//                              that can't handle a plain-text reply)
-		//   ModeNone → {type: "none"} (tools disabled for this call even if provided)
+		//   ModeNone -> {type: "none"} (tools disabled for this call even if provided)
 		//
 		// When AllowedFunctionNames holds exactly one name with ModeAny, Anthropic's
 		// equivalent is {type: "tool", name: "..."}. For multiple names we fall back
 		// to {type: "any"} because Anthropic's tool variant accepts a single name,
-		// not a list — same pragmatic choice as the OpenAI adapter. Callers who need
+		// not a list - same pragmatic choice as the OpenAI adapter. Callers who need
 		// a multi-function allowlist should rely on ModeAny plus prompt-level
 		// instructions to pick within the allowed set.
 		if req.Config.ToolConfig != nil && req.Config.ToolConfig.FunctionCallingConfig != nil {
@@ -474,8 +474,8 @@ func (m *Model) convertContentToMessage(content *genai.Content) (*anthropic.Mess
 		// otherwise. Thought parts can legitimately appear under a user
 		// role: the ADK contents processor rewrites events authored by a
 		// DIFFERENT agent as user-role "For context:" content
-		// (ConvertForeignEvent) and passes non-text parts — including
-		// signature-only thought parts — through verbatim. Those foreign
+		// (ConvertForeignEvent) and passes non-text parts - including
+		// signature-only thought parts - through verbatim. Those foreign
 		// reasoning blocks are useless as context (their signatures belong
 		// to another conversation anyway), so drop them instead of letting
 		// the API bounce the request.

--- a/genai/anthropic/anthropic_test.go
+++ b/genai/anthropic/anthropic_test.go
@@ -14,7 +14,7 @@ import (
 // Anthropic's ToolChoiceUnionParam is a discriminated union with four
 // mutually-exclusive variants (OfAuto / OfAny / OfTool / OfNone). We assert
 // on the variant pointers directly because the nested Type field uses
-// constant.* types whose in-memory zero value is the empty string — their
+// constant.* types whose in-memory zero value is the empty string - their
 // real discriminator is injected during marshaling, not at construction.
 // Checking the pointer-set pattern matches what GetType() does internally
 // and is what the marshaler keys off of.
@@ -50,7 +50,7 @@ func readVariant(tc anthropic.ToolChoiceUnionParam) toolChoiceVariant {
 // buildMessageParams must translate genai.ToolConfig.FunctionCallingConfig
 // into Anthropic's tool_choice field. Without this, models that drift into
 // plain-text replies (the same production symptom that motivated the OpenAI
-// adapter fix) cannot be forced into tool-calling mode via the ADK config —
+// adapter fix) cannot be forced into tool-calling mode via the ADK config -
 // the setting is silently dropped before it reaches the wire.
 func TestBuildMessageParams_ToolChoice(t *testing.T) {
 	cases := []struct {
@@ -107,7 +107,7 @@ func TestBuildMessageParams_ToolChoice(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Exercise the full path from LLMRequest to SDK params rather than
-			// poking at a private helper — keeps the test stable if the mapping
+			// poking at a private helper - keeps the test stable if the mapping
 			// is ever refactored into its own function.
 			params, err := m.buildMessageParams(&model.LLMRequest{Config: tc.cfg})
 			if err != nil {

--- a/genai/anthropic/caching.go
+++ b/genai/anthropic/caching.go
@@ -7,45 +7,33 @@ import (
 	"github.com/anthropics/anthropic-sdk-go"
 )
 
-// caching.go implements Anthropic prompt caching.
+// caching.go stamps Anthropic prompt-cache markers on a request.
 //
-// Anthropic's cache is OPT-IN and prefix-based: a `cache_control:
-// {"type":"ephemeral"}` marker on a content block tells the API
-// "everything from the start of the request up to and including this
-// block may be cached". A follow-up request whose prefix matches
-// byte-for-byte reads those tokens from cache at ~10% of the normal
-// input price (writing the cache the first time costs ~25% extra,
-// amortised from the second request on). Without markers nothing is
-// cached and every request bills its full input. Prefixes shorter
-// than the model's minimum cacheable length (1024-4096 tokens) are
-// silently not cached — the marker is legal but inert, so it is
-// always safe to set.
+// The cache is opt-in and prefix-based: a cache_control marker on a block
+// makes the API cache everything up to and including that block, and a later
+// request with a byte-identical prefix reads it back at ~10% of the input
+// price. Setting a marker is always safe: prefixes shorter than the model's
+// minimum cacheable length (1024-4096 tokens) are silently not cached.
 //
-// Anthropic caches in the order tools → system → messages and allows
-// at most 4 breakpoints per request. We spend 3, one per section:
+// Anthropic caches in the order tools -> system -> messages and allows at
+// most 4 breakpoints per request. We set 3:
 //
-//  1. The last tool definition. Tool schemas are construction-time
-//     constants for an agent, so this prefix is stable across every
-//     request of a session (and across sessions of the same agent).
+//  1. The last tool definition. Tool schemas are static per agent, so this
+//     prefix survives every request of a session.
 //
-//  2. The last system block. The system prompt is equally static.
-//     Separate from (1) so editing the prompt — e.g. a hot reload —
-//     invalidates only the system+messages cache, not the tools'.
+//  2. The last system block. Static too, and separate from (1) so editing
+//     the prompt (e.g. a hot reload) does not invalidate the tools cache.
 //
-//  3. The last cacheable block of the last message. This is the
-//     incremental marker: turn N's full conversation becomes turn
-//     N+1's cached prefix, which is where the bulk of the savings
-//     come from in agentic loops (each tool round-trip re-sends the
-//     whole history).
+//  3. The last cacheable block of the last message. Turn N's history becomes
+//     turn N+1's cached prefix; this is where the savings come from in
+//     agentic loops, which re-send the whole history on every tool
+//     round-trip. Thinking and redacted-thinking blocks cannot carry a
+//     marker, so this one walks backwards past them to the nearest eligible
+//     block.
 //
-// Thinking and redacted-thinking blocks cannot carry cache_control
-// (the SDK union exposes no slot for it), so marker (3) walks
-// backwards past them to the nearest eligible block.
-
-// applyCacheControl stamps the three breakpoints described above onto
-// params, in place. Call it as the LAST step of buildMessageParams so
-// every section is final (e.g. after repairMessageHistory, which can
-// reorder/merge message blocks).
+// applyCacheControl stamps the three breakpoints onto params, in place. Call
+// it as the LAST step of buildMessageParams so every section is final (e.g.
+// after repairMessageHistory, which can reorder/merge message blocks).
 func applyCacheControl(params *anthropic.MessageNewParams) {
 	marker := anthropic.NewCacheControlEphemeralParam()
 

--- a/genai/anthropic/core_test.go
+++ b/genai/anthropic/core_test.go
@@ -118,7 +118,7 @@ func TestConvertContentToMessage(t *testing.T) {
 // convertResponse rebuilds a genai.LLMResponse from the SDK's Anthropic
 // Message. We feed it a JSON-decoded Message rather than constructing one in
 // memory because the SDK's content blocks use an opaque discriminated union
-// whose fields are populated during unmarshal — building it manually would
+// whose fields are populated during unmarshal - building it manually would
 // require reaching into unexported state and create a brittle dependency on
 // the SDK's internals.
 func TestConvertResponse(t *testing.T) {

--- a/genai/anthropic/inline_data_test.go
+++ b/genai/anthropic/inline_data_test.go
@@ -19,7 +19,7 @@ import (
 //   - anything else is rejected with an error
 //
 // We assert on which OfXxx variant ends up populated, plus the relevant
-// payload field, instead of stringifying the entire union — that keeps the
+// payload field, instead of stringifying the entire union - that keeps the
 // tests stable across SDK refactors that may shuffle field names while
 // preserving the discriminator.
 func TestConvertInlineDataToBlock(t *testing.T) {
@@ -96,7 +96,7 @@ func TestConvertInlineDataToBlock(t *testing.T) {
 					t.Fatalf("expected plain-text source")
 				}
 				// Anthropic's plain-text source carries raw bytes verbatim,
-				// not base64 — that is the whole point of using OfText
+				// not base64 - that is the whole point of using OfText
 				// instead of OfBase64.
 				if txt.Data != string(c.data) {
 					t.Errorf("plain text data = %q, want %q", txt.Data, string(c.data))

--- a/genai/anthropic/stream_usage_test.go
+++ b/genai/anthropic/stream_usage_test.go
@@ -57,8 +57,8 @@ func sse(event, data string) string {
 
 // Gateways such as new-api (relaying an OpenAI-protocol upstream) send a
 // message_start whose usage is a pre-generation ESTIMATE with no cache
-// fields, and report the authoritative totals — including the prompt-caching
-// split — only in the final message_delta. The final response must carry the
+// fields, and report the authoritative totals - including the prompt-caching
+// split - only in the final message_delta. The final response must carry the
 // delta's numbers, not the estimate. Event sequence captured from a live
 // new-api endpoint.
 func TestStreamUsage_FinalDeltaAuthoritative(t *testing.T) {

--- a/genai/openai/core_test.go
+++ b/genai/openai/core_test.go
@@ -13,7 +13,7 @@ import (
 
 // convertSchema is the strongly-typed path used by ResponseSchema. We assert
 // on structural equality (a map[string]any tree) rather than serialised JSON
-// because Go's json.Marshal happens to sort map keys alphabetically — relying
+// because Go's json.Marshal happens to sort map keys alphabetically - relying
 // on that ordering implicitly would couple the test to an implementation
 // detail of the standard library that future Go versions don't have to
 // preserve.
@@ -235,7 +235,7 @@ func TestLowercaseTypes(t *testing.T) {
 // normalizeToolCallID hashes IDs longer than OpenAI's 40-char limit and
 // remembers the mapping so denormalize can recover the original. Short IDs
 // pass through untouched. The exact length of the shortened ID is part of
-// the contract — OpenAI rejects anything beyond 40 chars — so we assert on
+// the contract - OpenAI rejects anything beyond 40 chars - so we assert on
 // the boundary explicitly.
 func TestNormalizeToolCallID(t *testing.T) {
 	const limit = 40

--- a/genai/openai/messages_test.go
+++ b/genai/openai/messages_test.go
@@ -16,7 +16,7 @@ import (
 // OpenAI messages: function responses must become tool messages of their own,
 // while text/media/tool calls coalesce into a single role message. This test
 // pins down the resulting message shape (count, roles, payload) without
-// reaching into the SDK's union internals — we use a small kind() helper that
+// reaching into the SDK's union internals - we use a small kind() helper that
 // reads which OfXxx pointer is set.
 func TestConvertContentToMessages(t *testing.T) {
 	cases := []struct {

--- a/genai/openai/openai.go
+++ b/genai/openai/openai.go
@@ -147,7 +147,7 @@ func (m *Model) generateStream(ctx context.Context, req *model.LLMRequest) iter.
 		// Opt into the final usage chunk. Without stream_options.include_usage the
 		// server never emits it, the accumulator's Usage stays zero, and
 		// buildStreamFinalResponse yields a terminal LLMResponse with empty
-		// UsageMetadata — leaving consumers no way to price a streamed turn.
+		// UsageMetadata - leaving consumers no way to price a streamed turn.
 		params.StreamOptions.IncludeUsage = param.NewOpt(true)
 
 		stream := m.client.Chat.Completions.NewStreaming(ctx, params)
@@ -348,16 +348,16 @@ func (m *Model) applyGenerationConfig(params *openai.ChatCompletionNewParams, cf
 		}
 	}
 
-	// ToolConfig → tool_choice
+	// ToolConfig -> tool_choice
 	//
 	// Maps genai.FunctionCallingConfig.Mode to OpenAI's tool_choice:
-	//   ModeAuto → "auto"   (default behaviour; model may or may not call a tool)
-	//   ModeAny  → "required" (model MUST call a tool; use for agentic loops
+	//   ModeAuto -> "auto"   (default behaviour; model may or may not call a tool)
+	//   ModeAny  -> "required" (model MUST call a tool; use for agentic loops
 	//                         that can't handle a plain-text reply)
-	//   ModeNone → "none"   (tools disabled for this call even if provided)
+	//   ModeNone -> "none"   (tools disabled for this call even if provided)
 	//
 	// When AllowedFunctionNames is set with ModeAny, OpenAI's equivalent is a
-	// named function choice — we pick the first name since OpenAI's
+	// named function choice - we pick the first name since OpenAI's
 	// tool_choice accepts only one specific function, not a list. Callers who
 	// need a multi-function allowlist should rely on ModeAny plus prompt-level
 	// instructions to pick within the allowed set.
@@ -773,14 +773,12 @@ func convertInlineDataToPart(data *genai.Blob) (*openai.ChatCompletionContentPar
 
 // convertUsageMetadata converts OpenAI usage stats to genai format.
 //
-// CompletionTokensDetails.ReasoningTokens is the count of hidden reasoning
-// tokens billed as output tokens by OpenAI reasoning models (o-series,
-// gpt-5.x) and by OpenAI-compatible providers exposing reasoning (DeepSeek,
-// Kimi K2/K2.6, Qwen3-Thinking). PromptTokensDetails.CachedTokens is the
-// cache-hit subset of PromptTokens and is billed at a distinct input rate.
-// Both are documented parts of the official Chat Completions schema, so we
-// always map them to their genai counterparts. When a provider does not emit
-// a detail, the field is zero and genai serialisation omits it via `omitempty`.
+// ReasoningTokens (billed as output tokens by o-series, gpt-5.x and
+// reasoning-exposing compatible providers) maps to ThoughtsTokenCount;
+// CachedTokens (the cache-hit subset of PromptTokens, billed at a distinct
+// input rate) maps to CachedContentTokenCount. Both are documented Chat
+// Completions fields, so they are always mapped. A provider that omits a
+// detail leaves it at zero, and genai's omitempty drops it on the wire.
 func convertUsageMetadata(usage openai.CompletionUsage) *genai.GenerateContentResponseUsageMetadata {
 	if usage.TotalTokens == 0 {
 		return nil
@@ -797,22 +795,14 @@ func convertUsageMetadata(usage openai.CompletionUsage) *genai.GenerateContentRe
 // extractReasoningContent reads the non-standard "reasoning_content" field
 // from the SDK's raw JSON envelope.
 //
-// The OpenAI Chat Completions schema does NOT include a "reasoning_content"
-// field — for OpenAI's own reasoning models (o-series, gpt-5.x) the reasoning
-// text is hidden and only the token count is reported (via
-// CompletionTokensDetails.ReasoningTokens). Reasoning *text* is only
-// available through the Responses API, which this adapter does not use.
+// Chat Completions does not define this field: OpenAI's own reasoning models
+// hide the reasoning text and report only the token count. Compatible
+// providers (DeepSeek-R1, Kimi K2/K2.6, Qwen3-Thinking) add it on
+// choices[].message and choices[].delta. openai-go does not type it but
+// keeps it in the raw JSON, reachable via RawJSON().
 //
-// However, multiple OpenAI-compatible providers (DeepSeek-R1, Kimi K2/K2.6,
-// Qwen3-Thinking, etc.) extend the response with a "reasoning_content"
-// field on choices[].message and choices[].delta. openai-go does not type
-// this field but preserves it in JSON.raw, which is reachable via the
-// generated RawJSON() accessor. Parsing the raw envelope is the documented
-// way to read non-standard fields in this SDK.
-//
-// Returns "" if the field is absent, empty, or the JSON cannot be parsed —
-// callers should treat empty as "no reasoning content emitted" and skip
-// adding a thought Part.
+// Returns "" when the field is absent, empty, or unparseable; callers treat
+// empty as "no reasoning content" and skip the thought Part.
 func extractReasoningContent(rawJSON string) string {
 	if rawJSON == "" {
 		return ""

--- a/genai/openai/openai_test.go
+++ b/genai/openai/openai_test.go
@@ -14,7 +14,7 @@ import (
 // applyGenerationConfig must translate genai.ToolConfig.FunctionCallingConfig
 // into OpenAI's tool_choice field. Without this, models that drift into
 // plain-text replies under tool_choice="auto" (the OpenAI default) cannot be
-// forced into tool-calling mode via the ADK config — the setting is silently
+// forced into tool-calling mode via the ADK config - the setting is silently
 // dropped before it reaches the wire.
 func TestApplyGenerationConfig_ToolChoice(t *testing.T) {
 	cases := []struct {

--- a/genai/openai/response_test.go
+++ b/genai/openai/response_test.go
@@ -253,12 +253,12 @@ func TestConvertThinkingLevel(t *testing.T) {
 // from the raw JSON envelope that openai-go preserves on every typed
 // response struct. The function exists because OpenAI-compatible providers
 // (Kimi K2.6, DeepSeek-R1, Qwen3-Thinking, etc.) extend the Chat Completions
-// schema with this field, and openai-go does NOT type it — it lives only in
+// schema with this field, and openai-go does NOT type it - it lives only in
 // JSON.raw / ExtraFields.
 //
 // The contract is: return the field value verbatim if present and non-empty,
 // "" otherwise. Malformed JSON must yield "" rather than an error because
-// callers cannot meaningfully react to it — at the response-conversion
+// callers cannot meaningfully react to it - at the response-conversion
 // layer, dropping a thought Part is the safe degradation.
 func TestExtractReasoningContent(t *testing.T) {
 	cases := []struct {
@@ -315,7 +315,7 @@ func TestExtractReasoningContent(t *testing.T) {
 // Tests below build the response via json.Unmarshal because openai-go
 // stores the raw JSON envelope in an unexported `JSON.raw` field, populated
 // only by the generated UnmarshalJSON. Constructing the struct literally
-// would leave RawJSON() empty and bypass the field we are testing — a
+// would leave RawJSON() empty and bypass the field we are testing - a
 // false-positive trap that would let a regression slip through.
 func TestConvertResponse_WithReasoningContent(t *testing.T) {
 	t.Run("reasoning_content yields a leading Thought part", func(t *testing.T) {
@@ -403,7 +403,7 @@ func TestConvertResponse_WithReasoningContent(t *testing.T) {
 	t.Run("reasoning_content coexists with a tool call", func(t *testing.T) {
 		// The combined case matters because reasoning models often emit
 		// chain-of-thought *and* a tool call in the same turn. The Part
-		// order must be: thought → text → function call, reflecting the
+		// order must be: thought -> text -> function call, reflecting the
 		// temporal order the model produced them.
 		raw := []byte(`{
             "id": "chatcmpl-z",
@@ -415,7 +415,7 @@ func TestConvertResponse_WithReasoningContent(t *testing.T) {
                 "message": {
                     "role": "assistant",
                     "content": "Looking up weather.",
-                    "reasoning_content": "Need fresh data — call the weather tool.",
+                    "reasoning_content": "Need fresh data - call the weather tool.",
                     "tool_calls": [{
                         "id": "call_1",
                         "type": "function",

--- a/genai/openai/utils_test.go
+++ b/genai/openai/utils_test.go
@@ -11,8 +11,8 @@ import (
 )
 
 // schemaTypeToString is the mapping that ResponseSchema and other strongly
-// typed paths rely on. JSON Schema is case-sensitive — uppercase types are
-// invalid — so we have to assert each one explicitly. Unknown types must
+// typed paths rely on. JSON Schema is case-sensitive - uppercase types are
+// invalid - so we have to assert each one explicitly. Unknown types must
 // degrade to "string" rather than empty/error to avoid sending a schema with
 // an empty "type" field, which OpenAI rejects.
 func TestSchemaTypeToString(t *testing.T) {
@@ -42,7 +42,7 @@ func TestSchemaTypeToString(t *testing.T) {
 // convertRole is intentionally minimal: it only renames "model" to
 // "assistant" and passes everything else through untouched. The OpenAI SDK
 // validates roles upstream, so this adapter shouldn't second-guess unknown
-// values — it should hand them off as-is.
+// values - it should hand them off as-is.
 func TestConvertRole(t *testing.T) {
 	cases := []struct {
 		role string
@@ -116,7 +116,7 @@ func TestJoinTexts(t *testing.T) {
 	}
 }
 
-// parseJSONArgs must never return nil — agent code assumes the args map is
+// parseJSONArgs must never return nil - agent code assumes the args map is
 // always safe to index. Invalid JSON, empty input, and the literal "null"
 // must all map to an empty map rather than propagate the parse error.
 func TestParseJSONArgs(t *testing.T) {
@@ -142,7 +142,7 @@ func TestParseJSONArgs(t *testing.T) {
 }
 
 // extractText concatenates only the text parts of a Content with newlines.
-// Non-text parts must be skipped — they have no string representation we'd
+// Non-text parts must be skipped - they have no string representation we'd
 // want appearing inside an OpenAI message body.
 func TestExtractText(t *testing.T) {
 	cases := []struct {

--- a/genai/openai/wire_test.go
+++ b/genai/openai/wire_test.go
@@ -142,7 +142,7 @@ func captureStreamBody(t *testing.T, req *model.LLMRequest) map[string]any {
 // On the wire, a streaming request must set stream_options.include_usage=true.
 // Without this opt-in the OpenAI server never emits the terminal usage chunk,
 // the ChatCompletionAccumulator's Usage stays zero, and buildStreamFinalResponse
-// yields empty UsageMetadata — leaving consumers no way to price the turn.
+// yields empty UsageMetadata - leaving consumers no way to price the turn.
 func TestWireBody_StreamRequestsUsage(t *testing.T) {
 	body := captureStreamBody(t, &model.LLMRequest{
 		Config: &genai.GenerateContentConfig{},

--- a/plugin/contextguard/compaction_strategy_multiturn_test.go
+++ b/plugin/contextguard/compaction_strategy_multiturn_test.go
@@ -18,12 +18,12 @@ import (
 //
 // This simulator models the EXACT ADK execution flow as implemented in
 // internal/llminternal/base_flow.go. Every test that uses simulateSession
-// exercises the full pipeline: BeforeModelCallback → LLM → AfterModelCallback,
+// exercises the full pipeline: BeforeModelCallback -> LLM -> AfterModelCallback,
 // including re-entry for tool results.
 //
 // ADK flow per user turn:
 //
-//   OUTER: for { runOneStep() → if IsFinalResponse() → break }
+//   OUTER: for { runOneStep() -> if IsFinalResponse() -> break }
 //
 //   runOneStep():
 //     1. preprocess: create fresh req, ContentsRequestProcessor rebuilds
@@ -33,9 +33,9 @@ import (
 //        2b. Model.GenerateContent
 //        2c. AfterModelCallback (ContextGuard: persistRealTokens)
 //     3. postprocess
-//     4. handleFunctionCalls → execute tools → yield function response event
-//     5. if function calls exist → LOOP (another runOneStep)
-//        else → IsFinalResponse=true → BREAK
+//     4. handleFunctionCalls -> execute tools -> yield function response event
+//     5. if function calls exist -> LOOP (another runOneStep)
+//        else -> IsFinalResponse=true -> BREAK
 //
 // Key invariants we model:
 //   - Each runOneStep creates a FRESH req with contents from session history
@@ -146,7 +146,7 @@ func simulateSession(t *testing.T, cfg sessionConfig, turns []turnConfig) sessio
 	// rebuilds from session events and applies injectSummary.
 
 	// runLLMStep simulates one complete ADK runOneStep iteration:
-	//   preprocess → BeforeModelCallback → LLM → AfterModelCallback
+	//   preprocess -> BeforeModelCallback -> LLM -> AfterModelCallback
 	runLLMStep := func(turnIdx int, label string) {
 		// Step 1: ADK creates a fresh LLMRequest and ContentsRequestProcessor
 		// rebuilds Contents from the full session event history.
@@ -176,7 +176,7 @@ func simulateSession(t *testing.T, cfg sessionConfig, turns []turnConfig) sessio
 			result.compactions++
 			if tokensAfter >= tokensBefore {
 				result.loopDetected = true
-				t.Logf("Turn %d [%s]: LOOP — compaction had no effect: %d >= %d",
+				t.Logf("Turn %d [%s]: LOOP - compaction had no effect: %d >= %d",
 					turnIdx, label, tokensAfter, tokensBefore)
 			}
 		}
@@ -185,9 +185,9 @@ func simulateSession(t *testing.T, cfg sessionConfig, turns []turnConfig) sessio
 		// req.Contents only affects this LLM call. ContentsRequestProcessor
 		// will rebuild from ALL events next time, and injectSummary strips
 		// the already-summarized events using the watermark. We do NOT
-		// update `contents` here — it represents the immutable event history.
+		// update `contents` here - it represents the immutable event history.
 
-		// Step 3: Compute "real" token count — what the LLM would actually see.
+		// Step 3: Compute "real" token count - what the LLM would actually see.
 		// This is the ground truth for overflow detection.
 		realTokensForLLM := int(float64(tokensAfter) * cfg.tokenRatio)
 		if realTokensForLLM > result.maxTokensSeen {
@@ -195,11 +195,11 @@ func simulateSession(t *testing.T, cfg sessionConfig, turns []turnConfig) sessio
 		}
 		if realTokensForLLM > cfg.contextWindow {
 			result.overflowed = true
-			t.Logf("Turn %d [%s]: OVERFLOW — real tokens %d > context window %d (heuristic=%d, ratio=%.1f)",
+			t.Logf("Turn %d [%s]: OVERFLOW - real tokens %d > context window %d (heuristic=%d, ratio=%.1f)",
 				turnIdx, label, realTokensForLLM, cfg.contextWindow, tokensAfter, cfg.tokenRatio)
 		}
 
-		// Step 4: AfterModelCallback — persists the real PromptTokenCount
+		// Step 4: AfterModelCallback - persists the real PromptTokenCount
 		// that the provider reports. In real ADK this fires after every
 		// GenerateContent call, including after tool-result processing.
 		if cfg.hasUsageMetadata {
@@ -215,7 +215,7 @@ func simulateSession(t *testing.T, cfg sessionConfig, turns []turnConfig) sessio
 	}
 
 	for i, turn := range turns {
-		// User sends a message → appended to session events by ADK runner
+		// User sends a message -> appended to session events by ADK runner
 		userParts := []*genai.Part{{Text: turn.userMessage}}
 		for _, att := range turn.inlineData {
 			userParts = append(userParts, &genai.Part{
@@ -233,8 +233,8 @@ func simulateSession(t *testing.T, cfg sessionConfig, turns []turnConfig) sessio
 		if len(turn.toolCalls) > 0 {
 			if turn.sequential {
 				// Sequential tool chain: each tool call is a separate ADK
-				// runOneStep iteration. Model calls tool A → gets result →
-				// calls tool B → gets result → ... → returns text.
+				// runOneStep iteration. Model calls tool A -> gets result ->
+				// calls tool B -> gets result -> ... -> returns text.
 				for k, tc := range turn.toolCalls {
 					// Model response with single FunctionCall
 					contents = append(contents, &genai.Content{
@@ -296,7 +296,7 @@ func simulateSession(t *testing.T, cfg sessionConfig, turns []turnConfig) sessio
 			}
 		}
 
-		// Model produces final text response → IsFinalResponse()=true → BREAK
+		// Model produces final text response -> IsFinalResponse()=true -> BREAK
 		respSize := turn.responseSize
 		if respSize <= 0 {
 			respSize = 120
@@ -795,7 +795,7 @@ func TestStress_200k_100Turns_MixedWorkload(t *testing.T) {
 }
 
 // ==========================================================================
-// 8k CONTEXT WINDOW TESTS (small model — the hard case)
+// 8k CONTEXT WINDOW TESTS (small model - the hard case)
 // ==========================================================================
 
 func TestStress_8k_NormalConversation(t *testing.T) {
@@ -1156,7 +1156,7 @@ func TestStress_CompactionNoInfiniteLoop(t *testing.T) {
 }
 
 // ==========================================================================
-// BRUTAL STRESS TESTS — extreme scenarios designed to break compaction
+// BRUTAL STRESS TESTS - extreme scenarios designed to break compaction
 // ==========================================================================
 
 // TestBrutal_8k_ToolResponseBiggerThanWindow tests a tool response that
@@ -1218,7 +1218,7 @@ func TestBrutal_8k_EveryTurnExceedsWindow(t *testing.T) {
 // a token ratio up to the default correction factor (2.0x). Without
 // UsageMetadata the system can never learn the real ratio, so the default
 // factor must cover the gap. Ratio=2.0 is the maximum that 2.0x default
-// factor can handle — any higher requires provider calibration data.
+// factor can handle - any higher requires provider calibration data.
 func TestBrutal_8k_NoUsageMetadata_HighRatio(t *testing.T) {
 	turns := make([]turnConfig, 20)
 	for i := range turns {
@@ -1251,7 +1251,7 @@ func TestBrutal_8k_NoUsageMetadata_HighRatio(t *testing.T) {
 // (2.0) and the provider doesn't report UsageMetadata, the system has no
 // way to learn the real ratio. It still compacts but may briefly overflow.
 // This test verifies the system survives (doesn't loop or crash) and that
-// compaction still fires — even if overflow occurs.
+// compaction still fires - even if overflow occurs.
 func TestBrutal_8k_NoUsageMetadata_BeyondDefault(t *testing.T) {
 	turns := make([]turnConfig, 15)
 	for i := range turns {
@@ -1315,7 +1315,7 @@ func TestBrutal_8k_150Turns(t *testing.T) {
 }
 
 // TestBrutal_200k_ConsecutiveMassiveBursts tests multiple consecutive
-// turns each with massive tool output — the worst case for accumulation.
+// turns each with massive tool output - the worst case for accumulation.
 func TestBrutal_200k_ConsecutiveMassiveBursts(t *testing.T) {
 	turns := make([]turnConfig, 10)
 	for i := range turns {
@@ -1591,7 +1591,7 @@ func TestBrutal_8k_CorrectionFactorDrift(t *testing.T) {
 }
 
 // TestBrutal_8k_EmptyToolResponses tests tool calls that return empty
-// or near-empty responses — the FunctionResponse wrapper still costs tokens.
+// or near-empty responses - the FunctionResponse wrapper still costs tokens.
 func TestBrutal_8k_EmptyToolResponses(t *testing.T) {
 	turns := make([]turnConfig, 25)
 	for i := range turns {
@@ -1727,7 +1727,7 @@ func TestBrutal_8k_JSON_Heavy_ToolResponses(t *testing.T) {
 // SEQUENTIAL TOOL CHAIN TESTS
 //
 // These test the scenario where a model chains tool calls sequentially:
-// call tool A → get result → call tool B → get result → ... → text.
+// call tool A -> get result -> call tool B -> get result -> ... -> text.
 // Each tool call is a separate ADK runOneStep iteration, so
 // BeforeModelCallback fires before each one. This exercises the compaction
 // system much harder than parallel calls because context grows step-by-step.
@@ -1804,7 +1804,7 @@ func TestBrutal_200k_SequentialToolChain_LargeResponses(t *testing.T) {
 }
 
 // TestBrutal_8k_SequentialChain_NoUsageMetadata tests sequential tool
-// chains without calibration data — the hardest case for the heuristic.
+// chains without calibration data - the hardest case for the heuristic.
 func TestBrutal_8k_SequentialChain_NoUsageMetadata(t *testing.T) {
 	turns := make([]turnConfig, 10)
 	for i := range turns {
@@ -1838,7 +1838,7 @@ func TestBrutal_8k_SequentialChain_NoUsageMetadata(t *testing.T) {
 }
 
 // ==========================================================================
-// TOOL DEFINITIONS TESTS — verify that tool schemas are counted in the
+// TOOL DEFINITIONS TESTS - verify that tool schemas are counted in the
 // heuristic and compaction fires before overflow.
 // ==========================================================================
 
@@ -2009,7 +2009,7 @@ func TestBrutal_200k_ToolDefinitionsHighRatio(t *testing.T) {
 }
 
 // ==========================================================================
-// INLINE DATA TESTS — verify that InlineData (images, PDFs, audio, video)
+// INLINE DATA TESTS - verify that InlineData (images, PDFs, audio, video)
 // is counted in the heuristic.
 // ==========================================================================
 
@@ -2071,7 +2071,7 @@ func TestStress_8k_InlineSmallImages(t *testing.T) {
 }
 
 // TestBrutal_200k_LargeInlineDocuments tests large inline documents (e.g.
-// PDFs converted to base64). A 500KB PDF is ~125k heuristic tokens — a
+// PDFs converted to base64). A 500KB PDF is ~125k heuristic tokens - a
 // single attachment can nearly fill a 200k window.
 func TestBrutal_200k_LargeInlineDocuments(t *testing.T) {
 	turns := []turnConfig{
@@ -2104,7 +2104,7 @@ func TestBrutal_200k_LargeInlineDocuments(t *testing.T) {
 }
 
 // TestBrutal_200k_MultipleInlinePerTurn tests turns with multiple inline
-// attachments — simulating a user pasting several screenshots at once.
+// attachments - simulating a user pasting several screenshots at once.
 func TestBrutal_200k_MultipleInlinePerTurn(t *testing.T) {
 	turns := make([]turnConfig, 8)
 	for i := range turns {
@@ -2243,7 +2243,7 @@ func TestBrutal_8k_ToolDefsAndInlineCombined(t *testing.T) {
 }
 
 // ==========================================================================
-// REAL-WORLD USE CASE TESTS — production patterns from singleshot tests
+// REAL-WORLD USE CASE TESTS - production patterns from singleshot tests
 // ported to the multi-turn simulator for full ADK flow validation.
 //
 // These replicate the exact tool patterns from kubeAgentConversation,
@@ -2253,8 +2253,8 @@ func TestBrutal_8k_ToolDefsAndInlineCombined(t *testing.T) {
 // ==========================================================================
 
 // --- Kubernetes Agent Pattern ---
-// Each turn: user asks → model calls kubectl_get_pods (huge JSON) →
-// kubectl_describe_pod (huge text) → kubectl_get_logs (huge text) → model responds.
+// Each turn: user asks -> model calls kubectl_get_pods (huge JSON) ->
+// kubectl_describe_pod (huge text) -> kubectl_get_logs (huge text) -> model responds.
 // Matches kubeAgentConversation from singleshot tests.
 
 func TestStress_200k_KubeAgent(t *testing.T) {
@@ -2600,8 +2600,8 @@ func TestBrutal_8k_PureToolStorm_50Turns(t *testing.T) {
 }
 
 // --- Coding Agent Pattern ---
-// Each turn: user asks → model thinks (text response) → reads file → analyzes →
-// edits file → runs tests → model summarizes. Sequential tool chains.
+// Each turn: user asks -> model thinks (text response) -> reads file -> analyzes ->
+// edits file -> runs tests -> model summarizes. Sequential tool chains.
 // Matches buildCodingAgentConversation from singleshot tests.
 
 func TestStress_200k_CodingAgent(t *testing.T) {

--- a/plugin/contextguard/compaction_strategy_singleshot_test.go
+++ b/plugin/contextguard/compaction_strategy_singleshot_test.go
@@ -19,9 +19,9 @@ import (
 
 // kubeAgentConversation simulates a Kubernetes agent session:
 //   - User asks something
-//   - Model calls kubectl_get_pods → huge JSON response
-//   - Model calls kubectl_describe_pod → huge JSON response
-//   - Model calls kubectl_get_logs → huge text response
+//   - Model calls kubectl_get_pods -> huge JSON response
+//   - Model calls kubectl_describe_pod -> huge JSON response
+//   - Model calls kubectl_get_logs -> huge text response
 //   - Model responds with analysis
 //   - Repeat
 func kubeAgentConversation(rounds int) []*genai.Content {
@@ -217,7 +217,7 @@ func mixedConversation() []*genai.Content {
 			Name: "http_get", Response: map[string]any{"status": 200, "body": `{"status":"healthy","latency_p99":"180ms","error_rate":"0.001"}`},
 		}}}},
 
-		textContent("model", "Migration cancelled. The API health has recovered — P99 latency is back to 180ms and error rate dropped to 0.1%. I recommend adding the index with CREATE INDEX CONCURRENTLY during the next maintenance window."),
+		textContent("model", "Migration cancelled. The API health has recovered - P99 latency is back to 180ms and error rate dropped to 0.1%. I recommend adding the index with CREATE INDEX CONCURRENTLY during the next maintenance window."),
 	}
 }
 
@@ -423,8 +423,8 @@ func copyContents(src []*genai.Content) []*genai.Content {
 }
 
 // buildCodingAgentConversation simulates a coding assistant that reads files,
-// runs tests, edits code — alternating between text discussion and tool use.
-// Each round: user asks → model thinks (text) → model calls tool → result →
+// runs tests, edits code - alternating between text discussion and tool use.
+// Each round: user asks -> model thinks (text) -> model calls tool -> result ->
 // model analyzes (text). This is the best-case for safeSplitIndex because
 // there are text messages between tool chains.
 func buildCodingAgentConversation(rounds int) []*genai.Content {
@@ -618,7 +618,7 @@ func TestCompactionSimulation(t *testing.T) {
 	t.Log("\n=== TOKEN INCREASE / NO-REDUCTION DIAGNOSTIC ===\n")
 	for _, r := range results {
 		if r.summarized && r.tokensAfter >= r.tokensBefore {
-			t.Logf("  DIAG: [%s] strategy=%s — tokens went from %d to %d (floor-hit: oldMessages=%d, summary replaced 1 msg but added summary text)",
+			t.Logf("  DIAG: [%s] strategy=%s - tokens went from %d to %d (floor-hit: oldMessages=%d, summary replaced 1 msg but added summary text)",
 				r.scenario, r.strategy, r.tokensBefore, r.tokensAfter, r.oldMessages)
 		}
 	}
@@ -637,14 +637,14 @@ func TestCompactionSimulation(t *testing.T) {
 		}
 	}
 	if unfitCount == 0 {
-		t.Log("  (none — all compacted scenarios fit within context window)")
+		t.Log("  (none - all compacted scenarios fit within context window)")
 	}
 
 	// --- Report: how the floor affected things ---
 	t.Log("\n=== FLOOR-HIT ANALYSIS ===\n")
 	for _, r := range results {
 		if r.summarized && r.oldMessages <= 1 {
-			t.Logf("  FLOOR-HIT: [%s] strategy=%s — only %d message(s) summarized out of %d total (%.1f%% token reduction)",
+			t.Logf("  FLOOR-HIT: [%s] strategy=%s - only %d message(s) summarized out of %d total (%.1f%% token reduction)",
 				r.scenario, r.strategy, r.oldMessages, r.contentsBefore, r.reductionPct)
 		}
 	}
@@ -773,7 +773,7 @@ func TestCompactionInvestigation_RetryRoundsAndGiantResponses(t *testing.T) {
 		if r.fits {
 			fit = "YES"
 		}
-		t.Logf("  %-35s | %8d | %10d | %10d | %7.1f%% | %4d→%d | %s",
+		t.Logf("  %-35s | %8d | %10d | %10d | %7.1f%% | %4d->%d | %s",
 			r.scenario, r.attempts, r.tokensBefore, r.tokensAfter,
 			r.reductionPct, r.contentsBefore, r.contentsAfter, fit)
 	}
@@ -796,7 +796,7 @@ func TestCompactionInvestigation_RetryRoundsAndGiantResponses(t *testing.T) {
 		if r.fits {
 			fit = "YES"
 		}
-		t.Logf("  %-35s | %8d | %10d | %10d | %7.1f%% | %4d→%d | %s",
+		t.Logf("  %-35s | %8d | %10d | %10d | %7.1f%% | %4d->%d | %s",
 			r.scenario, r.attempts, r.tokensBefore, r.tokensAfter,
 			r.reductionPct, r.contentsBefore, r.contentsAfter, fit)
 	}
@@ -819,13 +819,13 @@ func TestCompactionInvestigation_RetryRoundsAndGiantResponses(t *testing.T) {
 		if r.fits {
 			fit = "YES"
 		}
-		t.Logf("  %-35s | %8d | %10d | %10d | %7.1f%% | %4d→%d | %s",
+		t.Logf("  %-35s | %8d | %10d | %10d | %7.1f%% | %4d->%d | %s",
 			r.scenario, r.attempts, r.tokensBefore, r.tokensAfter,
 			r.reductionPct, r.contentsBefore, r.contentsAfter, fit)
 	}
 
 	// =====================================================================
-	// PART 4: The real kube scenario — what size responses break things?
+	// PART 4: The real kube scenario - what size responses break things?
 	// =====================================================================
 	t.Log("\n\n=== PART 4: KUBE-LIKE CONVERSATIONS WITH VARYING RESPONSE SIZE ===\n")
 	t.Logf("  %-35s | %8s | %10s | %10s | %8s | %7s | %s",
@@ -843,14 +843,14 @@ func TestCompactionInvestigation_RetryRoundsAndGiantResponses(t *testing.T) {
 			if r.fits {
 				fit = "YES"
 			}
-			t.Logf("  %-35s | %8d | %10d | %10d | %7.1f%% | %4d→%d | %s",
+			t.Logf("  %-35s | %8d | %10d | %10d | %7.1f%% | %4d->%d | %s",
 				r.scenario, r.attempts, r.tokensBefore, r.tokensAfter,
 				r.reductionPct, r.contentsBefore, r.contentsAfter, fit)
 		}
 	}
 
 	// =====================================================================
-	// PART 5: Single giant response — the absolute worst case
+	// PART 5: Single giant response - the absolute worst case
 	// =====================================================================
 	t.Log("\n\n=== PART 5: SINGLE GIANT TOOL RESPONSE ===\n")
 	t.Logf("  %-35s | %8s | %10s | %10s | %8s | %7s | %s",
@@ -877,7 +877,7 @@ func TestCompactionInvestigation_RetryRoundsAndGiantResponses(t *testing.T) {
 			if r.fits {
 				fit = "YES"
 			}
-			t.Logf("  %-35s | %8d | %10d | %10d | %7.1f%% | %4d→%d | %s",
+			t.Logf("  %-35s | %8d | %10d | %10d | %7.1f%% | %4d->%d | %s",
 				r.scenario, r.attempts, r.tokensBefore, r.tokensAfter,
 				r.reductionPct, r.contentsBefore, r.contentsAfter, fit)
 		}
@@ -889,11 +889,11 @@ func TestCompactionInvestigation_RetryRoundsAndGiantResponses(t *testing.T) {
 // TestTimingGap_CalibratedHeuristicPreventsOverflow simulates the exact
 // scenario where stale real tokens alone would miss a context overflow:
 //
-//	Step N:   LLM sees 140k tokens → AfterModel persists 140k, heuristic was 70k
+//	Step N:   LLM sees 140k tokens -> AfterModel persists 140k, heuristic was 70k
 //	Tool:     Returns 80k-char response (≈20k heuristic tokens, ≈40k real tokens)
 //	Step N+1: BeforeModel has req with 140k real + 40k new tool = 180k actual.
-//	          Old tokenCount: returns 140k (stale) → 140k < 180k threshold → NO compaction → BOOM
-//	          New tokenCount: calibrated = (70k+20k) * (140k/70k) = 180k → triggers compaction → SAFE
+//	          Old tokenCount: returns 140k (stale) -> 140k < 180k threshold -> NO compaction -> BOOM
+//	          New tokenCount: calibrated = (70k+20k) * (140k/70k) = 180k -> triggers compaction -> SAFE
 //
 // This test verifies the calibrated heuristic correctly inflates the
 // current heuristic estimate using the correction factor from the previous
@@ -954,7 +954,7 @@ func TestTimingGap_CalibratedHeuristicPreventsOverflow(t *testing.T) {
 		t.Fatalf("test setup broken: stale real tokens (%d) already >= threshold (%d)", realTokensAtStepN, threshold)
 	}
 	if calibrated < threshold {
-		t.Logf("NOTE: calibrated (%d) < threshold (%d) — in this test scenario the growth is small enough", calibrated, threshold)
+		t.Logf("NOTE: calibrated (%d) < threshold (%d) - in this test scenario the growth is small enough", calibrated, threshold)
 	}
 
 	t.Logf("Context window=%d, threshold=%d, stale_real=%d, calibrated=%d",

--- a/plugin/contextguard/compaction_utils.go
+++ b/plugin/contextguard/compaction_utils.go
@@ -46,7 +46,7 @@ Required sections:
 
 ## Exact Next Steps
 
-Be specific. Don't write "continue with the task" — write exactly what should happen next, with enough detail that someone reading only this summary can pick up without asking questions.
+Be specific. Don't write "continue with the task" - write exactly what should happen next, with enough detail that someone reading only this summary can pick up without asking questions.
 
 Tone: Write as if briefing a colleague taking over mid-conversation. Include everything they would need to continue without asking questions. Write in the same language as the conversation.
 
@@ -723,7 +723,7 @@ func contentHasFunctionCall(c *genai.Content) bool {
 // If contentsAtCompaction is 0 or exceeds the current length, the summary
 // is simply prepended (first compaction or safety fallback).
 func injectSummary(req *model.LLMRequest, summary string, contentsAtCompaction int) {
-	summaryText := fmt.Sprintf("[Previous conversation summary]\n%s\n[End of summary — conversation continues below]", summary)
+	summaryText := fmt.Sprintf("[Previous conversation summary]\n%s\n[End of summary - conversation continues below]", summary)
 
 	if len(req.Contents) > 0 && req.Contents[0] != nil &&
 		req.Contents[0].Role == "user" && len(req.Contents[0].Parts) > 0 {
@@ -755,7 +755,7 @@ func replaceSummary(req *model.LLMRequest, summary string, recentContents []*gen
 	summaryContent := &genai.Content{
 		Role: "user",
 		Parts: []*genai.Part{
-			{Text: fmt.Sprintf("[Previous conversation summary]\n%s\n[End of summary — conversation continues below]", summary)},
+			{Text: fmt.Sprintf("[Previous conversation summary]\n%s\n[End of summary - conversation continues below]", summary)},
 		},
 	}
 	req.Contents = append([]*genai.Content{summaryContent}, recentContents...)

--- a/plugin/contextguard/contextguard.go
+++ b/plugin/contextguard/contextguard.go
@@ -1,23 +1,22 @@
 // SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
 // SPDX-License-Identifier: Apache-2.0
 
-// Package contextguard implements an ADK plugin that prevents conversations
-// from exceeding the LLM's context window. Before every model call it
-// delegates to a configurable Strategy that decides whether and how to
-// compact the conversation history.
+// Package contextguard implements an ADK plugin that compacts the
+// conversation history before it exceeds the LLM's context window. Before
+// every model call it delegates to a Strategy that decides whether and how
+// to compact.
 //
-// Two strategies are provided out of the box:
+// Two strategies:
 //
-//   - ThresholdStrategy: estimates token count and summarizes when the
-//     remaining capacity drops below a safety buffer (two-tier: fixed 20k
-//     for large windows, 20% for small ones). This is a reactive guard.
+//   - ThresholdStrategy compacts when the estimated token count crosses a
+//     safety buffer (fixed 20k for large windows, 20% for small ones).
+//     Reactive.
 //
-//   - SlidingWindowStrategy: compacts when the number of Content entries
-//     exceeds a configured maximum, regardless of token count. This is a
-//     preventive, periodic compaction based on turn count.
+//   - SlidingWindowStrategy compacts every N Content entries, regardless of
+//     token count. Periodic.
 //
-// Both strategies use the agent's own LLM for summarization and share the
-// same structured system prompt, state keys, and helper functions.
+// Both summarize with the agent's own LLM and share the same system prompt,
+// state keys, and helpers.
 //
 // Usage:
 //

--- a/plugin/contextguard/contextguard_unit_test.go
+++ b/plugin/contextguard/contextguard_unit_test.go
@@ -568,7 +568,7 @@ func TestInjectSummary_AddsSummary(t *testing.T) {
 func TestInjectSummary_NoDuplicate(t *testing.T) {
 	req := &model.LLMRequest{
 		Contents: []*genai.Content{
-			textContent("user", "[Previous conversation summary]\nold summary\n[End of summary — conversation continues below]"),
+			textContent("user", "[Previous conversation summary]\nold summary\n[End of summary - conversation continues below]"),
 			textContent("user", "hello"),
 		},
 	}
@@ -1252,7 +1252,7 @@ func makeLargeToolResultContent(name string, size int) *genai.Content {
 }
 
 // ---------------------------------------------------------------------------
-// Tests: Fix 1 — safeSplitIndex must never regress to 0
+// Tests: Fix 1 - safeSplitIndex must never regress to 0
 // ---------------------------------------------------------------------------
 
 func TestSafeSplitIndex_AllToolCalls_NeverReturnsZero(t *testing.T) {
@@ -1366,7 +1366,7 @@ func TestThresholdStrategy_IterativeCompaction(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Tests: Fix 2 — findSplitIndex must count FunctionCall/FunctionResponse tokens
+// Tests: Fix 2 - findSplitIndex must count FunctionCall/FunctionResponse tokens
 // ---------------------------------------------------------------------------
 
 func TestFindSplitIndex_ToolCallsCountTokens(t *testing.T) {
@@ -1418,7 +1418,7 @@ func TestFindSplitIndex_ToolCallsCountTokens(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Tests: End-to-end — threshold strategy compacts all-tool conversations
+// Tests: End-to-end - threshold strategy compacts all-tool conversations
 // ---------------------------------------------------------------------------
 
 func TestThresholdStrategy_AllToolCalls_StillCompacts(t *testing.T) {
@@ -1498,7 +1498,7 @@ func TestSlidingWindowStrategy_AllToolCalls_StillCompacts(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Tests: Proposal 5.1 — Real token counts via AfterModelCallback
+// Tests: Proposal 5.1 - Real token counts via AfterModelCallback
 // ---------------------------------------------------------------------------
 
 func TestPersistAndLoadRealTokens(t *testing.T) {
@@ -1739,7 +1739,7 @@ func TestThresholdStrategy_UsesRealTokens(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Tests: Full summary — threshold always summarizes everything (no recent tail)
+// Tests: Full summary - threshold always summarizes everything (no recent tail)
 // ---------------------------------------------------------------------------
 
 func TestThresholdStrategy_NoRecentTail(t *testing.T) {
@@ -1777,7 +1777,7 @@ func TestThresholdStrategy_NoRecentTail(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Tests: Proposal 5.3 — Continuation context injection
+// Tests: Proposal 5.3 - Continuation context injection
 // ---------------------------------------------------------------------------
 
 func TestInjectContinuation_WithUserContent(t *testing.T) {
@@ -1857,7 +1857,7 @@ func TestThresholdStrategy_InjectsContinuation(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Tests: Proposal 5.4 — Todo preservation in summary prompt
+// Tests: Proposal 5.4 - Todo preservation in summary prompt
 // ---------------------------------------------------------------------------
 
 func TestLoadTodos_Empty(t *testing.T) {
@@ -1964,7 +1964,7 @@ func TestPluginConfig_HasAfterModelCallback(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Tests: End-to-end — real tokens trigger compaction that heuristic misses
+// Tests: End-to-end - real tokens trigger compaction that heuristic misses
 // ---------------------------------------------------------------------------
 
 func TestThresholdStrategy_RealTokens_TriggersWhereHeuristicFails(t *testing.T) {
@@ -1975,8 +1975,8 @@ func TestThresholdStrategy_RealTokens_TriggersWhereHeuristicFails(t *testing.T) 
 
 	// Create a request where len/4 estimates ~50k tokens but "real" is 130k.
 	// With maxTokens=150k, threshold = 150k - 30k = 120k.
-	// Heuristic: 50k < 120k → no compaction.
-	// Real: 130k >= 120k → compaction.
+	// Heuristic: 50k < 120k -> no compaction.
+	// Real: 130k >= 120k -> compaction.
 	req := &model.LLMRequest{
 		Model:    "gpt-4o",
 		Contents: makeLargeConversation(50_000),

--- a/plugin/contextguard/model_registry.go
+++ b/plugin/contextguard/model_registry.go
@@ -5,7 +5,7 @@ package contextguard
 
 // ModelRegistry provides model metadata needed by the ContextGuard plugin.
 // Implementations can fetch data from a remote source, a local config, or
-// a static map — the plugin only depends on this interface.
+// a static map - the plugin only depends on this interface.
 type ModelRegistry interface {
 	// ContextWindow returns the maximum context window size (in tokens) for
 	// the given model ID. If the model is unknown, a reasonable default

--- a/plugin/contextguard/model_registry_crush.go
+++ b/plugin/contextguard/model_registry_crush.go
@@ -17,7 +17,7 @@ const (
 
 // CrushRegistry implements ModelRegistry using catwalk's embedded model
 // database. All model metadata (context windows, max tokens, costs) is
-// compiled into the binary — no network calls, no background goroutines.
+// compiled into the binary - no network calls, no background goroutines.
 //
 // Usage:
 //

--- a/plugin/langfuse/context.go
+++ b/plugin/langfuse/context.go
@@ -59,7 +59,7 @@ func TagsFromContext(ctx context.Context) []string {
 // langfuse.trace.metadata.<key> span attribute per entry.
 //
 // Multiple callers can cooperate by reading, copying, and extending the
-// existing map — the context itself is immutable so no mutex is needed.
+// existing map - the context itself is immutable so no mutex is needed.
 func WithTraceMetadata(ctx context.Context, metadata map[string]string) context.Context {
 	return context.WithValue(ctx, traceMetadataKey, metadata)
 }

--- a/plugin/langfuse/langfuse.go
+++ b/plugin/langfuse/langfuse.go
@@ -3,7 +3,7 @@
 
 // Package langfuse wires ADK Go telemetry to a Langfuse instance via OTLP/HTTP.
 //
-// It is fully self-contained — it has zero imports from any host application.
+// It is fully self-contained - it has zero imports from any host application.
 // Any project using the ADK can import this package as a library, call
 // Setup to configure the exporter and get back the plugin config and a
 // shutdown function.
@@ -155,26 +155,21 @@ type llmCall struct {
 // spanEnricher
 // ---------------------------------------------------------------------------
 
-// spanEnricher is the core state holder for the Langfuse ADK plugin. It
-// tracks in-flight agent spans and pending LLM calls so that the
+// spanEnricher tracks in-flight agent spans and pending LLM calls so the
 // enrichingExporter can attach request/response payloads to the correct
-// generate_content spans at export time.
+// generate_content span at export time.
 //
-// Keys are built from invocationID + branch (via branchKey) so that
-// ParallelAgent sub-agents running concurrently under the same invocation
-// never collide. For sequential flows the branch is empty and the key
-// degrades to the invocationID alone.
+// Keys combine invocationID and branch (see branchKey), so ParallelAgent
+// sub-agents under the same invocation never collide. Pending LLM calls are
+// keyed by the invoke_agent span ID the callbacks see; the exporter matches
+// them via the parent span ID of each generate_content span.
 //
-// Pending LLM calls are keyed by the invoke_agent span ID visible to the
-// callbacks. The enrichingExporter matches them by looking up the parent
-// span ID of each generate_content span (which is its invoke_agent ancestor).
-//
-// All callbacks return (nil, nil) — the plugin is a pure observer that never
-// alters agent behaviour or short-circuits the ADK callback chain.
+// All callbacks return (nil, nil): the plugin only observes, it never alters
+// agent behaviour or short-circuits the ADK callback chain.
 type spanEnricher struct {
 	mu         sync.Mutex
-	agentSpans map[string][]oteltrace.Span // branchKey → stack of invoke_agent spans
-	pending    map[string][]llmCall        // invoke_agent spanID → FIFO queue of LLM calls awaiting export
+	agentSpans map[string][]oteltrace.Span // branchKey -> stack of invoke_agent spans
+	pending    map[string][]llmCall        // invoke_agent spanID -> FIFO queue of LLM calls awaiting export
 }
 
 // branchKey builds the map key that isolates parallel branches. In
@@ -260,15 +255,11 @@ func (e *spanEnricher) afterAgent(ctx agent.Context) (*genai.Content, error) {
 	return nil, nil
 }
 
-// beforeModel is the BeforeModelCallback. It serialises the full LLM prompt
-// (system instruction, conversation history, tool calls/responses) and
-// enqueues it as a pending llmCall keyed by the invoke_agent span ID.
-//
-// ADK callbacks see the invoke_agent span in their context (the
-// generate_content span is created later, inside the ADK, and is never
-// visible to plugin callbacks). The enrichingExporter bridges the gap by
-// looking up pending calls via the parent span ID of each generate_content
-// span, which is the invoke_agent span ID stored here.
+// beforeModel serialises the full LLM prompt (system instruction, history,
+// tool calls) and enqueues it as a pending llmCall keyed by the invoke_agent
+// span ID. The generate_content span is created later inside the ADK and is
+// never visible to callbacks; the exporter bridges the gap by matching on
+// the parent span ID, which is the invoke_agent span ID stored here.
 func (e *spanEnricher) beforeModel(ctx agent.Context, req *model.LLMRequest) (*model.LLMResponse, error) {
 	span := oteltrace.SpanFromContext(ctx)
 	if !span.IsRecording() {
@@ -286,14 +277,11 @@ func (e *spanEnricher) beforeModel(ctx agent.Context, req *model.LLMRequest) (*m
 	return nil, nil
 }
 
-// afterModel is the AfterModelCallback. It captures the model's response
-// text (or the error message on failure), attaches it to the pending
-// llmCall, and — when the response is a non-partial final text answer (no
-// function calls) — propagates the output to the ancestor invoke_agent
-// spans in the same branch so that Langfuse shows the final answer at the
-// trace level. The check avoids resp.TurnComplete because that field is
-// only populated in streaming mode; instead it uses !Partial +
-// !hasFunctionCalls which works in both streaming and non-streaming flows.
+// afterModel attaches the model's response text (or the error) to the
+// pending llmCall. On a final text answer it also propagates the output to
+// the ancestor invoke_agent spans, so Langfuse shows it at trace level.
+// "Final" is detected as !Partial + !hasFunctionCalls, not TurnComplete:
+// TurnComplete is only set in streaming mode, and this must work in both.
 func (e *spanEnricher) afterModel(ctx agent.Context, resp *model.LLMResponse, llmErr error) (*model.LLMResponse, error) {
 	span := oteltrace.SpanFromContext(ctx)
 	if !span.IsRecording() {
@@ -367,7 +355,7 @@ func (e *spanEnricher) popCall(spanID string) (llmCall, bool) {
 // OTel spans.
 //
 // Pending calls are looked up by the parent span ID of each generate_content
-// span — that parent is the invoke_agent span whose ID was used as key by
+// span - that parent is the invoke_agent span whose ID was used as key by
 // the beforeModel/afterModel callbacks.
 type enrichingExporter struct {
 	inner    sdktrace.SpanExporter
@@ -512,7 +500,7 @@ func contentToText(c *genai.Content) string {
 			parts = append(parts, fmt.Sprintf("[tool_call: %s(%s)]", p.FunctionCall.Name, string(args)))
 		case p.FunctionResponse != nil:
 			resp, _ := json.Marshal(p.FunctionResponse.Response)
-			parts = append(parts, fmt.Sprintf("[tool_response: %s → %s]", p.FunctionResponse.Name, string(resp)))
+			parts = append(parts, fmt.Sprintf("[tool_response: %s -> %s]", p.FunctionResponse.Name, string(resp)))
 		}
 	}
 	return strings.Join(parts, "\n")

--- a/plugin/langfuse/langfuse_test.go
+++ b/plugin/langfuse/langfuse_test.go
@@ -327,7 +327,7 @@ func TestContentToText(t *testing.T) {
 		}}}, `[tool_call: search({"q":"foo"})]`},
 		{"function response", &genai.Content{Parts: []*genai.Part{{
 			FunctionResponse: &genai.FunctionResponse{Name: "search", Response: map[string]any{"ok": true}},
-		}}}, `[tool_response: search → {"ok":true}]`},
+		}}}, `[tool_response: search -> {"ok":true}]`},
 		{"mixed", &genai.Content{Parts: []*genai.Part{
 			{Text: "hi"},
 			{FunctionCall: &genai.FunctionCall{Name: "f", Args: map[string]any{}}},


### PR DESCRIPTION
## What

Three commits, one goal: make the repo read like a person wrote it, per the new rules.

1. **`.agents/STYLE.md`** (new): the writing rules, linked from AGENTS.md. Write for the reader of each text (a code comment is a short objective fact, the README talks to a human, the .agents/ docs orient agents), living documentation rather than a changelog, no typographic Unicode, no decision-ID references outside .agents/, component names in words.

2. **ASCII cleanup**: em-dashes, en-dashes, arrows and ellipsis characters out of code comments, test strings, the README and the .agents/ prose. Diagram box characters stay: a diagram is not prose.

3. **Rewrite of article-style comments**: the handful of comments that read like launch posts (caching.go, contextguard.go, langfuse.go, openai.go) are now short facts. Also fixes two stale comments describing a CrushRegistry that no longer exists: the README example called `Start`/`Stop` on a registry that has no lifecycle, and the context-guard example mentioned a provider.json fetch that was replaced by catwalk's embedded database. The README example now matches the real API.

## Testing

No behaviour change: comments, docs, test fixtures and log strings only. Build, vet, gofmt and the full test suite are green.