### PR TITLE
fix(genai): filter ADK internal confirmation protocol from provider requests

### DIFF
--- a/genai/anthropic/anthropic.go
+++ b/genai/anthropic/anthropic.go
@@ -522,6 +522,12 @@ func (m *Model) convertContentToMessage(content *genai.Content) (*anthropic.Mess
 		}
 
 		if part.FunctionCall != nil {
+			// Skip ADK internal framework parts (HITL confirmation
+			// protocol): they are not tools the model declared, and
+			// replaying them breaks tool_use/tool_result pairing.
+			if common.IsADKInternalCall(part.FunctionCall.Name) {
+				continue
+			}
 			input, err := common.MarshalToolPayload(part.FunctionCall.Args)
 			if err != nil {
 				return nil, fmt.Errorf("failed to marshal function call args: %w", err)
@@ -536,6 +542,9 @@ func (m *Model) convertContentToMessage(content *genai.Content) (*anthropic.Mess
 		}
 
 		if part.FunctionResponse != nil {
+			if common.IsADKInternalCall(part.FunctionResponse.Name) {
+				continue
+			}
 			responseJSON, err := common.MarshalToolPayload(part.FunctionResponse.Response)
 			if err != nil {
 				return nil, fmt.Errorf("failed to marshal function response: %w", err)

--- a/genai/anthropic/confirmation_filter_test.go
+++ b/genai/anthropic/confirmation_filter_test.go
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
+package anthropic
+
+import (
+	"reflect"
+	"testing"
+
+	"google.golang.org/adk/v2/tool/toolconfirmation"
+	"google.golang.org/genai"
+)
+
+// ADK's HITL confirmation protocol stores internal function calls and
+// responses (name "adk_request_confirmation") in the session. They are
+// framework bookkeeping, not tools the model declared; replaying them breaks
+// tool_use/tool_result pairing on the wire. The conversion must drop them
+// while keeping the real tool exchange intact.
+func TestConvertContentToMessage_DropsADKConfirmationParts(t *testing.T) {
+	m := &Model{}
+
+	assistant := &genai.Content{
+		Role: "model",
+		Parts: []*genai.Part{
+			{FunctionCall: &genai.FunctionCall{
+				ID:   "call_real",
+				Name: "create_enrollment",
+				Args: map[string]any{"email": "a@b.c"},
+			}},
+			{FunctionCall: &genai.FunctionCall{
+				ID:   "adk_confirm_1",
+				Name: toolconfirmation.FunctionCallName,
+				Args: map[string]any{"confirmed": true},
+			}},
+		},
+	}
+
+	msg, err := m.convertContentToMessage(assistant)
+	if err != nil {
+		t.Fatalf("convertContentToMessage error: %v", err)
+	}
+	if msg == nil {
+		t.Fatal("expected a message, got nil")
+	}
+	if got, want := blockTypes(msg.Content), []string{"tool_use"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("block types = %v, want %v", got, want)
+	}
+	if got := msg.Content[0].OfToolUse.Name; got != "create_enrollment" {
+		t.Errorf("remaining tool_use name = %q, want %q", got, "create_enrollment")
+	}
+
+	user := &genai.Content{
+		Role: "user",
+		Parts: []*genai.Part{
+			{FunctionResponse: &genai.FunctionResponse{
+				ID:       "adk_confirm_1",
+				Name:     toolconfirmation.FunctionCallName,
+				Response: map[string]any{"confirmed": true},
+			}},
+			{FunctionResponse: &genai.FunctionResponse{
+				ID:       "call_real",
+				Name:     "create_enrollment",
+				Response: map[string]any{"ok": true},
+			}},
+		},
+	}
+
+	msg, err = m.convertContentToMessage(user)
+	if err != nil {
+		t.Fatalf("convertContentToMessage error: %v", err)
+	}
+	if msg == nil {
+		t.Fatal("expected a message, got nil")
+	}
+	if got, want := blockTypes(msg.Content), []string{"tool_result"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("block types = %v, want %v", got, want)
+	}
+	if got := msg.Content[0].OfToolResult.ToolUseID; got != sanitizeToolID("call_real") {
+		t.Errorf("remaining tool_result ToolUseID = %q, want %q", got, sanitizeToolID("call_real"))
+	}
+}
+
+// A confirmation-only turn must yield no message (nil, nil), matching the
+// empty-content contract the caller relies on to drop the turn.
+func TestConvertContentToMessage_ConfirmationOnlyTurnProducesNothing(t *testing.T) {
+	m := &Model{}
+
+	content := &genai.Content{
+		Role: "model",
+		Parts: []*genai.Part{
+			{FunctionCall: &genai.FunctionCall{
+				ID:   "adk_confirm_1",
+				Name: toolconfirmation.FunctionCallName,
+				Args: map[string]any{},
+			}},
+		},
+	}
+
+	msg, err := m.convertContentToMessage(content)
+	if err != nil {
+		t.Fatalf("convertContentToMessage error: %v", err)
+	}
+	if msg != nil {
+		t.Errorf("expected nil message, got %#v", msg)
+	}
+}

--- a/genai/common/payload.go
+++ b/genai/common/payload.go
@@ -5,7 +5,11 @@
 // rules are implemented once.
 package common
 
-import "encoding/json"
+import (
+	"encoding/json"
+
+	"google.golang.org/adk/v2/tool/toolconfirmation"
+)
 
 var emptyJSONObject = json.RawMessage(`{}`)
 
@@ -33,4 +37,13 @@ func MarshalToolPayload(payload any) (json.RawMessage, error) {
 		return emptyJSONObject, nil
 	}
 	return data, nil
+}
+
+// IsADKInternalCall reports whether a function call or response name belongs
+// to an internal ADK framework protocol (e.g. HITL tool confirmation) rather
+// than to a model-declared tool. Adapters must skip these parts: they are
+// framework bookkeeping and upstream providers reject them with 400 because
+// they are not tools the model has declared.
+func IsADKInternalCall(name string) bool {
+	return name == toolconfirmation.FunctionCallName
 }

--- a/genai/common/payload_test.go
+++ b/genai/common/payload_test.go
@@ -44,3 +44,25 @@ func TestMarshalToolPayload(t *testing.T) {
 		})
 	}
 }
+
+// ADK internal protocol names must be recognised so adapters can drop them;
+// anything model-declared must pass through untouched.
+func TestIsADKInternalCall(t *testing.T) {
+	cases := []struct {
+		name string
+		want bool
+	}{
+		{"adk_request_confirmation", true},
+		{"get_weather", false},
+		{"adk_request_confirmation_extra", false},
+		{"", false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := IsADKInternalCall(c.name); got != c.want {
+				t.Errorf("IsADKInternalCall(%q) = %v, want %v", c.name, got, c.want)
+			}
+		})
+	}
+}

--- a/genai/openai/confirmation_filter_test.go
+++ b/genai/openai/confirmation_filter_test.go
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
+package openai
+
+import (
+	"testing"
+
+	"google.golang.org/adk/v2/tool/toolconfirmation"
+	"google.golang.org/genai"
+)
+
+// ADK's HITL confirmation protocol stores internal function calls and
+// responses (name "adk_request_confirmation") in the session. They are
+// framework bookkeeping, not tools the model declared; forwarding them makes
+// OpenAI reject the request because tool messages must pair with tool_calls.
+// The conversion must drop them while keeping the real tool exchange intact.
+func TestConvertContentToMessages_DropsADKConfirmationParts(t *testing.T) {
+	m := newModelForTest()
+
+	assistant := &genai.Content{
+		Role: "model",
+		Parts: []*genai.Part{
+			{FunctionCall: &genai.FunctionCall{
+				ID:   "call_real",
+				Name: "create_enrollment",
+				Args: map[string]any{"email": "a@b.c"},
+			}},
+			{FunctionCall: &genai.FunctionCall{
+				ID:   "adk_confirm_1",
+				Name: toolconfirmation.FunctionCallName,
+				Args: map[string]any{"confirmed": true},
+			}},
+		},
+	}
+
+	msgs, err := m.convertContentToMessages(assistant)
+	if err != nil {
+		t.Fatalf("convertContentToMessages error: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 assistant message, got %d", len(msgs))
+	}
+	calls := msgs[0].OfAssistant.ToolCalls
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 tool call after filtering, got %d", len(calls))
+	}
+	if got := calls[0].OfFunction.Function.Name; got != "create_enrollment" {
+		t.Errorf("remaining tool call name = %q, want %q", got, "create_enrollment")
+	}
+
+	user := &genai.Content{
+		Role: "user",
+		Parts: []*genai.Part{
+			{FunctionResponse: &genai.FunctionResponse{
+				ID:       "adk_confirm_1",
+				Name:     toolconfirmation.FunctionCallName,
+				Response: map[string]any{"confirmed": true},
+			}},
+			{FunctionResponse: &genai.FunctionResponse{
+				ID:       "call_real",
+				Name:     "create_enrollment",
+				Response: map[string]any{"ok": true},
+			}},
+		},
+	}
+
+	msgs, err = m.convertContentToMessages(user)
+	if err != nil {
+		t.Fatalf("convertContentToMessages error: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 tool message after filtering, got %d", len(msgs))
+	}
+	if got := msgs[0].OfTool.ToolCallID; got != "call_real" {
+		t.Errorf("remaining tool message ToolCallID = %q, want %q", got, "call_real")
+	}
+}
+
+// A confirmation-only turn must produce no messages at all, so the replayed
+// history carries no empty assistant/user shells for the framework parts.
+func TestConvertContentToMessages_ConfirmationOnlyTurnProducesNothing(t *testing.T) {
+	m := newModelForTest()
+
+	content := &genai.Content{
+		Role: "model",
+		Parts: []*genai.Part{
+			{FunctionCall: &genai.FunctionCall{
+				ID:   "adk_confirm_1",
+				Name: toolconfirmation.FunctionCallName,
+				Args: map[string]any{},
+			}},
+		},
+	}
+
+	msgs, err := m.convertContentToMessages(content)
+	if err != nil {
+		t.Fatalf("convertContentToMessages error: %v", err)
+	}
+	if len(msgs) != 0 {
+		t.Errorf("expected no messages, got %d", len(msgs))
+	}
+}

--- a/genai/openai/openai.go
+++ b/genai/openai/openai.go
@@ -400,6 +400,12 @@ func (m *Model) convertContentToMessages(content *genai.Content) ([]openai.ChatC
 	for _, part := range content.Parts {
 		switch {
 		case part.FunctionResponse != nil:
+			// Skip ADK internal framework parts (HITL confirmation
+			// protocol): upstream providers reject them as undeclared
+			// tool messages.
+			if common.IsADKInternalCall(part.FunctionResponse.Name) {
+				continue
+			}
 			responseJSON, err := common.MarshalToolPayload(part.FunctionResponse.Response)
 			if err != nil {
 				return nil, fmt.Errorf("failed to marshal function response: %w", err)
@@ -408,6 +414,9 @@ func (m *Model) convertContentToMessages(content *genai.Content) ([]openai.ChatC
 			messages = append(messages, openai.ToolMessage(string(responseJSON), normalizedID))
 
 		case part.FunctionCall != nil:
+			if common.IsADKInternalCall(part.FunctionCall.Name) {
+				continue
+			}
 			argsJSON, err := common.MarshalToolPayload(part.FunctionCall.Args)
 			if err != nil {
 				return nil, fmt.Errorf("failed to marshal function args: %w", err)


### PR DESCRIPTION
## What

Filters the internal function calls and responses of ADK's HITL confirmation protocol (`adk_request_confirmation`) out of the history the OpenAI and Anthropic adapters send upstream.

Fixes #36.

## Why

When `mcptoolset.RequireConfirmationProvider` is active, the session stores framework-generated pairs named `adk_request_confirmation` alongside the real tool exchange. The native Gemini path drops them in ADK's own contents processor before the model call, but these adapters convert every `FunctionCall`/`FunctionResponse` into provider messages. Providers then reject the request with a 400: the name is not a tool the model declared, and the tool-call/tool-result pairing no longer balances.

## Changes

- `genai/common`: new `IsADKInternalCall(name)` helper backed by `toolconfirmation.FunctionCallName` from adk/v2, so the rule is implemented once and adapters share it.
- `genai/openai` (`convertContentToMessages`) and `genai/anthropic` (`convertContentToMessage`): skip call and response parts with that name during conversion.

## Tests

Conversion tests in both adapters: a history mixing the confirmation pair with a legitimate tool exchange keeps only the legitimate one, and a confirmation-only turn produces no messages. A mutation check (filter removed) fails all of them, so they guard the behaviour rather than describe it. `go test -race` green on `genai/common`, `genai/openai`, `genai/anthropic`.

## Scope

Only `toolconfirmation.FunctionCallName` is filtered. The workflow `adk_request_input` and credential-request names are out of scope for this fix.